### PR TITLE
Instance Unification impl

### DIFF
--- a/src/main/java/org/spongepowered/mod/SpongeCoremod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeCoremod.java
@@ -52,6 +52,10 @@ public class SpongeCoremod implements IFMLLoadingPlugin {
         };
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public String getModContainerClass() {
         return "org.spongepowered.mod.SpongeMod";

--- a/src/main/java/org/spongepowered/mod/SpongeGame.java
+++ b/src/main/java/org/spongepowered/mod/SpongeGame.java
@@ -24,8 +24,17 @@
  */
 package org.spongepowered.mod;
 
-import com.google.common.base.Optional;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
 import net.minecraftforge.fml.common.FMLCommonHandler;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.GameRegistry;
 import org.spongepowered.api.MinecraftVersion;
@@ -41,18 +50,17 @@ import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.mod.service.scheduler.AsyncScheduler;
 import org.spongepowered.mod.service.scheduler.SyncScheduler;
 
-import javax.annotation.Nullable;
-import javax.inject.Inject;
+import com.google.common.base.Optional;
 
 @NonnullByDefault
 public final class SpongeGame implements Game {
 
-    @Nullable
-    private static final String apiVersion = Game.class.getPackage().getImplementationVersion();
-    @Nullable
-    private static final String implementationVersion = SpongeGame.class.getPackage().getImplementationVersion();
+    @Nullable private static final String apiVersion = Game.class.getPackage().getImplementationVersion();
+    @Nullable private static final String implementationVersion = SpongeGame.class.getPackage().getImplementationVersion();
 
-    private static final MinecraftVersion MINECRAFT_VERSION = new SpongeMinecraftVersion("1.8", 47); // TODO: Keep updated
+    private static final MinecraftVersion MINECRAFT_VERSION = new SpongeMinecraftVersion("1.8", 47); // TODO:
+                                                                                                     // Keep
+                                                                                                     // updated
 
     private final PluginManager pluginManager;
     private final EventManager eventManager;
@@ -70,9 +78,9 @@ public final class SpongeGame implements Game {
     @Override
     public Platform getPlatform() {
         switch (FMLCommonHandler.instance().getEffectiveSide()) {
-            case CLIENT:
+            case CLIENT :
                 return Platform.CLIENT;
-            default:
+            default :
                 return Platform.SERVER;
         }
     }
@@ -130,5 +138,106 @@ public final class SpongeGame implements Game {
     @Override
     public Optional<Server> getServer() {
         return Optional.fromNullable((Server) FMLCommonHandler.instance().getMinecraftServerInstance());
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return new FlowerPotCheckBuilder().isFlowerPot();
+    }
+
+    private static class FlowerPotCheckBuilder implements Opcodes, Checker {
+
+        FlowerPotClassLoader cl = new FlowerPotClassLoader();
+        Class<?> cls;
+
+        public FlowerPotCheckBuilder() {
+            try {
+                this.cls = this.cl.defineClass("org.spongepowered.mod.SpongeGame$FlowerPotChecker", build());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        public boolean isFlowerPot() {
+            try {
+                return ((Checker) cls.newInstance()).isFlowerPot();
+            } catch (InstantiationException e) {
+                e.printStackTrace();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+            return false;
+        }
+
+        public byte[] build() throws Exception {
+
+            ClassWriter cw = new ClassWriter(0);
+            FieldVisitor fv;
+            MethodVisitor mv;
+            AnnotationVisitor av0;
+
+            cw.visit(V1_6, ACC_PUBLIC + ACC_SUPER, "org/spongepowered/mod/SpongeGame$FlowerPotChecker", null, "java/lang/Object",
+                    new String[] { "org/spongepowered/mod/SpongeGame$Checker" });
+
+            cw.visitSource("SpongeGame.java", null);
+
+            cw.visitInnerClass("org/spongepowered/mod/SpongeGame$Checker", "org/spongepowered/mod/SpongeGame", "Checker", ACC_STATIC + ACC_ABSTRACT
+                    + ACC_INTERFACE);
+
+            cw.visitInnerClass("org/spongepowered/mod/SpongeGame$FlowerPotChecker", "org/spongepowered/mod/SpongeGame", "FlowerPotChecker", 0);
+
+            {
+                fv = cw.visitField(ACC_FINAL + ACC_SYNTHETIC, "this$0", "Lorg/spongepowered/mod/SpongeGame;", null, null);
+                fv.visitEnd();
+            }
+            {
+                mv = cw.visitMethod(0, "<init>", "(Lorg/spongepowered/mod/SpongeGame;)V", null, null);
+                mv.visitCode();
+                Label l0 = new Label();
+                mv.visitLabel(l0);
+                mv.visitLineNumber(245, l0);
+                mv.visitVarInsn(ALOAD, 0);
+                mv.visitVarInsn(ALOAD, 1);
+                mv.visitFieldInsn(PUTFIELD, "org/spongepowered/mod/SpongeGame$FlowerPotChecker", "this$0", "Lorg/spongepowered/mod/SpongeGame;");
+                mv.visitVarInsn(ALOAD, 0);
+                mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+                mv.visitInsn(RETURN);
+                Label l1 = new Label();
+                mv.visitLabel(l1);
+                mv.visitLocalVariable("this", "Lorg/spongepowered/mod/SpongeGame$FlowerPotChecker;", null, l0, l1, 0);
+                mv.visitMaxs(2, 2);
+                mv.visitEnd();
+            }
+            {
+                mv = cw.visitMethod(ACC_PUBLIC + ACC_SYNCHRONIZED, "isFlowerPot", "()Z", null, null);
+                mv.visitCode();
+                Label l0 = new Label();
+                mv.visitLabel(l0);
+                mv.visitLineNumber(249, l0);
+                mv.visitInsn(ICONST_0);
+                mv.visitInsn(IRETURN);
+                Label l1 = new Label();
+                mv.visitLabel(l1);
+                mv.visitLocalVariable("this", "Lorg/spongepowered/mod/SpongeGame$FlowerPotChecker;", null, l0, l1, 0);
+                mv.visitMaxs(1, 1);
+                mv.visitEnd();
+            }
+            cw.visitEnd();
+
+            return cw.toByteArray();
+        }
+
+        class FlowerPotClassLoader extends ClassLoader {
+
+            public Class<?> defineClass(String name, byte[] cls) {
+                return defineClass(name, cls, 0, cls.length);
+            }
+        }
+
+    }
+
+    public static interface Checker {
+
+        boolean isFlowerPot();
     }
 }

--- a/src/main/java/org/spongepowered/mod/SpongeMinecraftVersion.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMinecraftVersion.java
@@ -25,6 +25,7 @@
 package org.spongepowered.mod;
 
 import com.google.common.base.MoreObjects;
+
 import org.spongepowered.api.MinecraftVersion;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 
@@ -94,5 +95,10 @@ public class SpongeMinecraftVersion implements ProtocolMinecraftVersion {
                 .add("name", this.name)
                 .add("protocol", this.protocol)
                 .toString();
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/SpongeMod.java
+++ b/src/main/java/org/spongepowered/mod/SpongeMod.java
@@ -29,6 +29,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.DummyModContainer;
@@ -43,6 +44,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 import net.minecraftforge.fml.relauncher.Side;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.Type;
@@ -240,5 +242,10 @@ public class SpongeMod extends DummyModContainer implements PluginContainer {
     @Override
     public Object getInstance() {
         return getMod();
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/asm/transformers/BaseEventTransformer.java
+++ b/src/main/java/org/spongepowered/mod/asm/transformers/BaseEventTransformer.java
@@ -42,6 +42,10 @@ import java.util.ListIterator;
 
 public class BaseEventTransformer implements IClassTransformer {
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public byte[] transform(String name, String transformedName, byte[] bytes) {
 

--- a/src/main/java/org/spongepowered/mod/asm/transformers/EventTransformer.java
+++ b/src/main/java/org/spongepowered/mod/asm/transformers/EventTransformer.java
@@ -56,6 +56,10 @@ import java.util.Map;
 @Cancelable
 public class EventTransformer implements IClassTransformer {
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private static final Map<String, Class<?>> events = new HashMap<String, Class<?>>();
 
     static {

--- a/src/main/java/org/spongepowered/mod/asm/transformers/SpongeAccessTransformer.java
+++ b/src/main/java/org/spongepowered/mod/asm/transformers/SpongeAccessTransformer.java
@@ -34,4 +34,8 @@ public class SpongeAccessTransformer extends AccessTransformer {
     public SpongeAccessTransformer() throws IOException {
         super("sponge_at.cfg");
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/block/meta/SpongeBannerData.java
+++ b/src/main/java/org/spongepowered/mod/block/meta/SpongeBannerData.java
@@ -30,6 +30,7 @@ import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+
 import org.spongepowered.api.block.tile.Banner;
 import org.spongepowered.api.block.tile.data.BannerData;
 import org.spongepowered.api.block.tile.data.BannerPatternShape;
@@ -91,5 +92,10 @@ public class SpongeBannerData implements BannerData {
         container.set(of("Base"), this.base);
         container.set(of("Patterns"), this.patterns);
         return container;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/block/meta/SpongeBeaconData.java
+++ b/src/main/java/org/spongepowered/mod/block/meta/SpongeBeaconData.java
@@ -27,6 +27,7 @@ package org.spongepowered.mod.block.meta;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Optional;
+
 import org.spongepowered.api.block.tile.carrier.Beacon;
 import org.spongepowered.api.block.tile.data.BeaconData;
 import org.spongepowered.api.potion.PotionEffectType;
@@ -82,5 +83,10 @@ public class SpongeBeaconData implements BeaconData {
     @Override
     public DataContainer toContainer() {
         return new MemoryDataContainer();
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/block/meta/SpongeLockableData.java
+++ b/src/main/java/org/spongepowered/mod/block/meta/SpongeLockableData.java
@@ -28,6 +28,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 
 import com.google.common.base.Optional;
+
 import org.spongepowered.api.block.tile.TileEntity;
 import org.spongepowered.api.block.tile.data.LockableData;
 import org.spongepowered.api.service.persistence.data.DataContainer;
@@ -66,5 +67,10 @@ public class SpongeLockableData implements LockableData {
         DataContainer container = new MemoryDataContainer();
         container.set(of("Lock"), this.lockToken);
         return container;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/block/meta/SpongeNotePitch.java
+++ b/src/main/java/org/spongepowered/mod/block/meta/SpongeNotePitch.java
@@ -48,4 +48,9 @@ public class SpongeNotePitch implements NotePitch {
         return this.name;
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/block/meta/SpongePatternLayer.java
+++ b/src/main/java/org/spongepowered/mod/block/meta/SpongePatternLayer.java
@@ -60,4 +60,9 @@ public class SpongePatternLayer implements PatternLayer {
         return container;
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/block/meta/SpongeSkullType.java
+++ b/src/main/java/org/spongepowered/mod/block/meta/SpongeSkullType.java
@@ -53,4 +53,9 @@ public class SpongeSkullType implements SkullType {
     public Translation getTranslation() {
         return null;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/command/CommandSponge.java
+++ b/src/main/java/org/spongepowered/mod/command/CommandSponge.java
@@ -70,6 +70,10 @@ public class CommandSponge extends CommandBase {
         return "sponge";
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @SuppressWarnings("rawtypes")
     @Override
     public List getCommandAliases() {

--- a/src/main/java/org/spongepowered/mod/command/MinecraftCommandWrapper.java
+++ b/src/main/java/org/spongepowered/mod/command/MinecraftCommandWrapper.java
@@ -25,6 +25,7 @@
 package org.spongepowered.mod.command;
 
 import com.google.common.collect.ImmutableList;
+
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandHandler;
 import net.minecraft.command.CommandResultStats;
@@ -34,6 +35,7 @@ import net.minecraft.command.PlayerSelector;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.fml.common.ModContainer;
+
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.api.text.format.TextColors;
@@ -154,5 +156,10 @@ public class MinecraftCommandWrapper implements CommandCallable {
     @SuppressWarnings("unchecked")
     public List<String> getNames() {
         return ImmutableList.<String>builder().add(this.command.getCommandName()).addAll(this.command.getCommandAliases()).build();
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/command/WrapperICommandSender.java
+++ b/src/main/java/org/spongepowered/mod/command/WrapperICommandSender.java
@@ -51,6 +51,10 @@ public class WrapperICommandSender implements ICommandSender {
         return this.source.getName();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public IChatComponent getDisplayName() {
         return ((SpongeText) Texts.of(this.source.getName())).toComponent();

--- a/src/main/java/org/spongepowered/mod/configuration/SpongeConfig.java
+++ b/src/main/java/org/spongepowered/mod/configuration/SpongeConfig.java
@@ -53,6 +53,14 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
         Type(Class<? extends ConfigBase> type) {
             this.type = type;
         }
+
+        public boolean isFlowerPot() {
+            return false;
+        }
+    }
+
+    public boolean isFlowerPot() {
+        return false;
     }
 
     public static final String CONFIG_ENABLED = "config-enabled";

--- a/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleEffect.java
+++ b/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleEffect.java
@@ -25,6 +25,7 @@
 package org.spongepowered.mod.effect.particle;
 
 import com.flowpowered.math.vector.Vector3d;
+
 import org.spongepowered.api.effect.particle.ParticleEffect;
 import org.spongepowered.api.item.inventory.ItemStack;
 
@@ -66,6 +67,11 @@ public class SpongeParticleEffect implements ParticleEffect {
         return this.count;
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public static class Colored extends SpongeParticleEffect implements ParticleEffect.Colorable {
 
         private Color color;
@@ -78,6 +84,11 @@ public class SpongeParticleEffect implements ParticleEffect {
         @Override
         public Color getColor() {
             return this.color;
+        }
+
+        @Override
+        public boolean isFlowerPot() {
+            return false;
         }
 
     }
@@ -96,6 +107,11 @@ public class SpongeParticleEffect implements ParticleEffect {
             return this.size;
         }
 
+        @Override
+        public boolean isFlowerPot() {
+            return false;
+        }
+
     }
 
     public static class Note extends SpongeParticleEffect implements ParticleEffect.Note {
@@ -112,6 +128,11 @@ public class SpongeParticleEffect implements ParticleEffect {
             return this.note;
         }
 
+        @Override
+        public boolean isFlowerPot() {
+            return false;
+        }
+
     }
 
     public static class Materialized extends SpongeParticleEffect implements ParticleEffect.Material {
@@ -126,6 +147,11 @@ public class SpongeParticleEffect implements ParticleEffect {
         @Override
         public ItemStack getItem() {
             return this.item;
+        }
+
+        @Override
+        public boolean isFlowerPot() {
+            return false;
         }
 
     }

--- a/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleEffectBuilder.java
+++ b/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleEffectBuilder.java
@@ -28,7 +28,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.math.vector.Vector3d;
+
 import net.minecraft.item.Item;
+
 import org.spongepowered.api.effect.particle.ParticleEffectBuilder;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -74,6 +76,11 @@ public class SpongeParticleEffectBuilder implements ParticleEffectBuilder {
         return new SpongeParticleEffect(this.type, this.motion, this.offset, this.count);
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public static class BuilderColorable extends SpongeParticleEffectBuilder implements ParticleEffectBuilder.Colorable {
 
         private Color color;
@@ -108,6 +115,11 @@ public class SpongeParticleEffectBuilder implements ParticleEffectBuilder {
         @Override
         public SpongeParticleEffect.Colored build() {
             return new SpongeParticleEffect.Colored(this.type, this.motion, this.offset, this.color, this.count);
+        }
+
+        @Override
+        public boolean isFlowerPot() {
+            return false;
         }
 
     }
@@ -148,6 +160,11 @@ public class SpongeParticleEffectBuilder implements ParticleEffectBuilder {
             return new SpongeParticleEffect.Resized(this.type, this.motion, this.offset, this.size, this.count);
         }
 
+        @Override
+        public boolean isFlowerPot() {
+            return false;
+        }
+
     }
 
     public static class BuilderNote extends SpongeParticleEffectBuilder implements ParticleEffectBuilder.Note {
@@ -184,6 +201,11 @@ public class SpongeParticleEffectBuilder implements ParticleEffectBuilder {
         @Override
         public SpongeParticleEffect.Note build() {
             return new SpongeParticleEffect.Note(this.type, this.motion, this.offset, this.note, this.count);
+        }
+
+        @Override
+        public boolean isFlowerPot() {
+            return false;
         }
 
     }
@@ -229,6 +251,11 @@ public class SpongeParticleEffectBuilder implements ParticleEffectBuilder {
         @Override
         public SpongeParticleEffect.Materialized build() {
             return new SpongeParticleEffect.Materialized(this.type, this.motion, this.offset, this.item, this.count);
+        }
+
+        @Override
+        public boolean isFlowerPot() {
+            return false;
         }
 
     }

--- a/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleHelper.java
+++ b/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleHelper.java
@@ -194,6 +194,10 @@ public final class SpongeParticleHelper {
         return packets;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private SpongeParticleHelper() {
     }
 }

--- a/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleType.java
+++ b/src/main/java/org/spongepowered/mod/effect/particle/SpongeParticleType.java
@@ -25,6 +25,7 @@
 package org.spongepowered.mod.effect.particle;
 
 import net.minecraft.util.EnumParticleTypes;
+
 import org.spongepowered.api.effect.particle.ParticleType;
 import org.spongepowered.api.item.inventory.ItemStack;
 
@@ -54,6 +55,11 @@ public class SpongeParticleType implements ParticleType {
         return this.motion;
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public static class Colorable extends SpongeParticleType implements ParticleType.Colorable {
 
         private Color color;
@@ -66,6 +72,11 @@ public class SpongeParticleType implements ParticleType {
         @Override
         public Color getDefaultColor() {
             return this.color;
+        }
+
+        @Override
+        public boolean isFlowerPot() {
+            return false;
         }
 
     }
@@ -84,6 +95,11 @@ public class SpongeParticleType implements ParticleType {
             return this.size;
         }
 
+        @Override
+        public boolean isFlowerPot() {
+            return true;
+        }
+
     }
 
     public static class Note extends SpongeParticleType implements ParticleType.Note {
@@ -98,6 +114,11 @@ public class SpongeParticleType implements ParticleType {
         @Override
         public float getDefaultNote() {
             return this.note;
+        }
+
+        @Override
+        public boolean isFlowerPot() {
+            return false;
         }
 
     }
@@ -115,6 +136,11 @@ public class SpongeParticleType implements ParticleType {
         @Override
         public ItemStack getDefaultItem() {
             return ItemStack.class.cast(this.item.copy());
+        }
+
+        @Override
+        public boolean isFlowerPot() {
+            return false;
         }
 
     }

--- a/src/main/java/org/spongepowered/mod/effect/sound/SpongeSound.java
+++ b/src/main/java/org/spongepowered/mod/effect/sound/SpongeSound.java
@@ -39,4 +39,9 @@ public class SpongeSound implements SoundType {
     public String getName() {
         return this.name;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/entity/SpongeCareer.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeCareer.java
@@ -53,4 +53,9 @@ public class SpongeCareer extends SpongeEntityMeta implements Career {
     public Translation getTranslation() {
         return null;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/entity/SpongeEntityConstants.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeEntityConstants.java
@@ -90,6 +90,10 @@ public class SpongeEntityConstants {
     public static final SpongeHorseVariant UNDEAD_HORSE = new SpongeHorseVariant(3, "UNDEAD_HORSE");
     public static final SpongeHorseVariant SKELETON_HORSE = new SpongeHorseVariant(4, "SKELETON_HORSE");
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     static {
         SKELETON_TYPES.put("NORMAL", NORMAL_SKELETON);
         SKELETON_TYPES.put("WITHER", WITHER_SKELETON);

--- a/src/main/java/org/spongepowered/mod/entity/SpongeEntityType.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeEntityType.java
@@ -25,8 +25,10 @@
 package org.spongepowered.mod.entity;
 
 import com.google.common.base.MoreObjects;
+
 import net.minecraft.entity.Entity;
 import net.minecraftforge.fml.common.registry.EntityRegistry.EntityRegistration;
+
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.text.translation.Translation;
 
@@ -115,5 +117,10 @@ public class SpongeEntityType implements EntityType {
     @Override
     public Translation getTranslation() {
         return null;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/entity/SpongeHorseColor.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeHorseColor.java
@@ -32,4 +32,9 @@ public class SpongeHorseColor extends SpongeEntityMeta implements HorseColor {
         super(color, name);
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false == true;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/entity/SpongeHorseStyle.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeHorseStyle.java
@@ -32,4 +32,9 @@ public class SpongeHorseStyle extends SpongeEntityMeta implements HorseStyle {
         super(style, name);
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/entity/SpongeHorseVariant.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeHorseVariant.java
@@ -37,4 +37,9 @@ public class SpongeHorseVariant extends SpongeEntityMeta implements HorseVariant
     public Translation getTranslation() {
         return null;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/entity/SpongeOcelotType.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeOcelotType.java
@@ -32,4 +32,9 @@ public class SpongeOcelotType extends SpongeEntityMeta implements OcelotType {
         super(type, name);
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/entity/SpongeProfession.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeProfession.java
@@ -44,4 +44,9 @@ public class SpongeProfession extends SpongeEntityMeta implements Profession {
     public Translation getTranslation() {
         return null;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/entity/SpongeRabbitType.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeRabbitType.java
@@ -32,4 +32,9 @@ public class SpongeRabbitType extends SpongeEntityMeta implements RabbitType {
         super(type, name);
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/entity/SpongeSkeletonType.java
+++ b/src/main/java/org/spongepowered/mod/entity/SpongeSkeletonType.java
@@ -32,4 +32,9 @@ public class SpongeSkeletonType extends SpongeEntityMeta implements SkeletonType
         super(type, name);
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/entity/player/gamemode/SpongeGameMode.java
+++ b/src/main/java/org/spongepowered/mod/entity/player/gamemode/SpongeGameMode.java
@@ -34,4 +34,9 @@ public class SpongeGameMode implements GameMode {
         return null;
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/entity/projectile/ProjectileSourceSerializer.java
+++ b/src/main/java/org/spongepowered/mod/entity/projectile/ProjectileSourceSerializer.java
@@ -56,6 +56,10 @@ public class ProjectileSourceSerializer {
         return null;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public static ProjectileSource fromNbt(World worldObj, NBTBase tag) {
         if (tag instanceof NBTTagString) {
             Entity entity =

--- a/src/main/java/org/spongepowered/mod/event/EventListenerHolder.java
+++ b/src/main/java/org/spongepowered/mod/event/EventListenerHolder.java
@@ -37,6 +37,10 @@ public abstract class EventListenerHolder<T> {
         return this.listeners.length == 0;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public void add(PriorityEventListener<T> listener) {
         if (listener.getHolder() != null) {
             throw new IllegalArgumentException("Listener already contained in a listener holder");

--- a/src/main/java/org/spongepowered/mod/event/EventRegistry.java
+++ b/src/main/java/org/spongepowered/mod/event/EventRegistry.java
@@ -57,6 +57,10 @@ public class EventRegistry {
     private EventRegistry() {
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     static {
         // FML state events
         register(FMLConstructionEvent.class, ConstructionEvent.class);

--- a/src/main/java/org/spongepowered/mod/event/HandlerCache.java
+++ b/src/main/java/org/spongepowered/mod/event/HandlerCache.java
@@ -62,4 +62,8 @@ class HandlerCache {
         return this.orderGrouped.get(order);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/event/HandlerClassFactory.java
+++ b/src/main/java/org/spongepowered/mod/event/HandlerClassFactory.java
@@ -97,6 +97,10 @@ class HandlerClassFactory implements HandlerFactory {
         this.targetPackage = targetPackage;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Handler createHandler(Object object, Method method, boolean ignoreCancelled) {
         synchronized (this.cache) {

--- a/src/main/java/org/spongepowered/mod/event/InvokeHandlerFactory.java
+++ b/src/main/java/org/spongepowered/mod/event/InvokeHandlerFactory.java
@@ -38,6 +38,10 @@ class InvokeHandlerFactory implements HandlerFactory {
         return new InvokeHandler(object, method, ignoreCancelled);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private static class InvokeHandler implements Handler {
 
         private final Object object;
@@ -48,6 +52,10 @@ class InvokeHandlerFactory implements HandlerFactory {
             this.object = object;
             this.method = method;
             this.ignoreCancelled = ignoreCancelled;
+        }
+
+        public boolean isFlowerPot() {
+            return false;
         }
 
         @Override

--- a/src/main/java/org/spongepowered/mod/event/PriorityEventListener.java
+++ b/src/main/java/org/spongepowered/mod/event/PriorityEventListener.java
@@ -45,6 +45,10 @@ public class PriorityEventListener<T> implements EventListener<T>, Comparable<Pr
         this.holder = holder;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void invoke(T event) {
         this.listener.invoke(event);

--- a/src/main/java/org/spongepowered/mod/event/RegisteredHandler.java
+++ b/src/main/java/org/spongepowered/mod/event/RegisteredHandler.java
@@ -44,6 +44,10 @@ class RegisteredHandler implements Comparable<RegisteredHandler> {
         return new RegisteredHandler(handler, null, null);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public Handler getHandler() {
         return this.handler;
     }

--- a/src/main/java/org/spongepowered/mod/event/SpongeEventBus.java
+++ b/src/main/java/org/spongepowered/mod/event/SpongeEventBus.java
@@ -37,8 +37,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.Inject;
+
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.IEventListener;
+
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.plugin.PluginManager;
 import org.spongepowered.api.service.event.EventManager;
@@ -293,6 +295,11 @@ public class SpongeEventBus implements EventManager {
         }
 
         return event instanceof Cancellable && ((Cancellable) event).isCancelled();
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/event/SpongeEventHooks.java
+++ b/src/main/java/org/spongepowered/mod/event/SpongeEventHooks.java
@@ -52,4 +52,8 @@ public class SpongeEventHooks {
         SpongeHooks.logEntityDeath(event.entity);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/event/Subscriber.java
+++ b/src/main/java/org/spongepowered/mod/event/Subscriber.java
@@ -52,6 +52,10 @@ class Subscriber {
         return this.eventClass;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public Handler getHandler() {
         return this.handler;
     }

--- a/src/main/java/org/spongepowered/mod/guice/ConfigDirAnnotation.java
+++ b/src/main/java/org/spongepowered/mod/guice/ConfigDirAnnotation.java
@@ -62,6 +62,10 @@ class ConfigDirAnnotation implements ConfigDir {
         return sharedRoot() == that.sharedRoot();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public int hashCode() {
         return (127 * "sharedRoot".hashCode()) ^ Boolean.valueOf(sharedRoot()).hashCode();

--- a/src/main/java/org/spongepowered/mod/guice/SpongeGuiceModule.java
+++ b/src/main/java/org/spongepowered/mod/guice/SpongeGuiceModule.java
@@ -52,4 +52,8 @@ public class SpongeGuiceModule extends AbstractModule {
         bind(GameRegistry.class).to(SpongeGameRegistry.class).in(Scopes.SINGLETON);
         bind(File.class).annotatedWith(new ConfigDirAnnotation(true)).toInstance(Loader.instance().getConfigDir());
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/guice/SpongePluginGuiceModule.java
+++ b/src/main/java/org/spongepowered/mod/guice/SpongePluginGuiceModule.java
@@ -72,6 +72,10 @@ public class SpongePluginGuiceModule extends AbstractModule {
                 .toProvider(PluginPrivateHoconConfigProvider.class); // loader for plugin-private directory config file
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     // This is strange, but required for Guice and annotations with values.
     private static class ConfigFileAnnotation implements DefaultConfig {
 

--- a/src/main/java/org/spongepowered/mod/item/ItemsHelper.java
+++ b/src/main/java/org/spongepowered/mod/item/ItemsHelper.java
@@ -27,10 +27,12 @@ package org.spongepowered.mod.item;
 import static org.spongepowered.mod.service.persistence.NbtTranslator.getInstance;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.state.BlockState;
 import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
+
 import org.spongepowered.api.item.ItemBlock;
 import org.spongepowered.api.item.ItemDataTransactionResult;
 import org.spongepowered.api.item.ItemType;
@@ -61,6 +63,11 @@ public final class ItemsHelper {
         @Override
         public Optional<Collection<ItemData<?>>> getReplacedData() {
             return Optional.absent();
+        }
+
+        @Override
+        public boolean isFlowerPot() {
+            return false;
         }
     };
 

--- a/src/main/java/org/spongepowered/mod/item/SpongeCoalType.java
+++ b/src/main/java/org/spongepowered/mod/item/SpongeCoalType.java
@@ -38,4 +38,9 @@ public class SpongeCoalType extends SpongeEntityMeta implements CoalType {
     public String getId() {
         return this.getName();
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/item/SpongeFireworkBuilder.java
+++ b/src/main/java/org/spongepowered/mod/item/SpongeFireworkBuilder.java
@@ -28,6 +28,7 @@ package org.spongepowered.mod.item;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.Lists;
+
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.FireworkEffectBuilder;
 import org.spongepowered.api.item.FireworkShape;
@@ -125,5 +126,10 @@ public class SpongeFireworkBuilder implements FireworkEffectBuilder {
         this.fades = Lists.newArrayList();
         this.shape = FireworkShapes.BALL;
         return this;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/item/SpongeFireworkMeta.java
+++ b/src/main/java/org/spongepowered/mod/item/SpongeFireworkMeta.java
@@ -29,6 +29,7 @@ import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.FireworkShape;
 import org.spongepowered.api.service.persistence.data.DataContainer;
@@ -52,6 +53,11 @@ public class SpongeFireworkMeta implements FireworkEffect {
         this.colors = ImmutableList.copyOf(colors);
         this.fades = ImmutableList.copyOf(fades);
         this.shape = shape;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/item/SpongeItemStackBuilder.java
+++ b/src/main/java/org/spongepowered/mod/item/SpongeItemStackBuilder.java
@@ -31,7 +31,9 @@ import static org.spongepowered.mod.item.ItemsHelper.validateData;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
+
 import net.minecraft.item.Item;
+
 import org.spongepowered.api.item.ItemDataTransactionResult;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.data.ItemData;
@@ -123,6 +125,11 @@ public class SpongeItemStackBuilder implements ItemStackBuilder {
         this.maxQuantity = 64;
         this.itemDataSet = Sets.newHashSet();
         return this;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/item/data/SpongeDurabilityData.java
+++ b/src/main/java/org/spongepowered/mod/item/data/SpongeDurabilityData.java
@@ -29,11 +29,13 @@ import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
 import net.minecraft.item.ItemTool;
+
 import org.spongepowered.api.item.ItemDataTransactionResult;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.data.DurabilityData;
@@ -61,6 +63,11 @@ public class SpongeDurabilityData extends AbstractItemData implements Durability
         this.durability = stack.getItemDamage();
         this.maxDurability = stack.getItem().getMaxDamage();
         this.breakable = stack.isItemStackDamageable();
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override
@@ -123,6 +130,11 @@ public class SpongeDurabilityData extends AbstractItemData implements Durability
             public Optional<Collection<ItemData<?>>> getReplacedData() {
                 return Optional.<Collection<ItemData<?>>>of(ImmutableSet.<ItemData<?>>of(new SpongeDurabilityData(stack)));
             }
+
+            @Override
+            public boolean isFlowerPot() {
+                return false;
+            }
         };
     }
 
@@ -141,6 +153,11 @@ public class SpongeDurabilityData extends AbstractItemData implements Durability
             @Override
             public Optional<Collection<ItemData<?>>> getReplacedData() {
                 return Optional.absent();
+            }
+
+            @Override
+            public boolean isFlowerPot() {
+                return false;
             }
         };
     }

--- a/src/main/java/org/spongepowered/mod/item/data/SpongeDyeableData.java
+++ b/src/main/java/org/spongepowered/mod/item/data/SpongeDyeableData.java
@@ -28,6 +28,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
+
 import net.minecraft.block.BlockColored;
 import net.minecraft.entity.passive.EntitySheep;
 import net.minecraft.init.Items;
@@ -37,6 +38,7 @@ import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+
 import org.spongepowered.api.item.DyeColor;
 import org.spongepowered.api.item.ItemDataTransactionResult;
 import org.spongepowered.api.item.ItemType;
@@ -65,6 +67,11 @@ public class SpongeDyeableData extends AbstractItemData implements DyeableItemDa
     public void set(DyeColor value) {
         checkNotNull(value);
         this.color = value;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override
@@ -147,6 +154,11 @@ public class SpongeDyeableData extends AbstractItemData implements DyeableItemDa
             @Override
             public Optional<Collection<ItemData<?>>> getReplacedData() {
                 return Optional.absent();
+            }
+
+            @Override
+            public boolean isFlowerPot() {
+                return false;
             }
         };
     }

--- a/src/main/java/org/spongepowered/mod/item/data/SpongeEnchantment.java
+++ b/src/main/java/org/spongepowered/mod/item/data/SpongeEnchantment.java
@@ -50,4 +50,9 @@ public class SpongeEnchantment implements DataSerializable {
         container.set(of("Level"), this.level);
         return container;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/item/data/SpongeEnchantmentItemData.java
+++ b/src/main/java/org/spongepowered/mod/item/data/SpongeEnchantmentItemData.java
@@ -32,7 +32,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+
 import net.minecraft.item.ItemStack;
+
 import org.spongepowered.api.item.Enchantment;
 import org.spongepowered.api.item.ItemDataTransactionResult;
 import org.spongepowered.api.item.ItemType;
@@ -64,6 +66,11 @@ public class SpongeEnchantmentItemData extends AbstractItemData implements Encha
         public Optional<Collection<ItemData<?>>> getReplacedData() {
             return Optional.absent();
         }
+
+        @Override
+        public boolean isFlowerPot() {
+            return false;
+        }
     };
     private Map<Enchantment, Integer> enchantments = Maps.newHashMap();
 
@@ -77,6 +84,11 @@ public class SpongeEnchantmentItemData extends AbstractItemData implements Encha
         for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
             this.setUnsafe(entry.getKey(), entry.getValue());
         }
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override
@@ -225,6 +237,11 @@ public class SpongeEnchantmentItemData extends AbstractItemData implements Encha
             public Optional<Collection<ItemData<?>>> getReplacedData() {
                 return Optional.absent();
             }
+
+            @Override
+            public boolean isFlowerPot() {
+                return false;
+            }
         };
     }
 
@@ -245,6 +262,11 @@ public class SpongeEnchantmentItemData extends AbstractItemData implements Encha
             public Optional<Collection<ItemData<?>>> getReplacedData() {
                 return Optional.absent();
             }
+
+            @Override
+            public boolean isFlowerPot() {
+                return false;
+            }
         };
     }
 
@@ -264,6 +286,11 @@ public class SpongeEnchantmentItemData extends AbstractItemData implements Encha
             public Optional<Collection<ItemData<?>>> getReplacedData() {
                 return Optional.<Collection<ItemData<?>>>of(set);
             }
+
+            @Override
+            public boolean isFlowerPot() {
+                return false;
+            }
         };
     }
 
@@ -282,6 +309,11 @@ public class SpongeEnchantmentItemData extends AbstractItemData implements Encha
             @Override
             public Optional<Collection<ItemData<?>>> getReplacedData() {
                 return Optional.<Collection<ItemData<?>>>of(build);
+            }
+
+            @Override
+            public boolean isFlowerPot() {
+                return false;
             }
         };
     }

--- a/src/main/java/org/spongepowered/mod/item/merchant/SpongeTradeOfferBuilder.java
+++ b/src/main/java/org/spongepowered/mod/item/merchant/SpongeTradeOfferBuilder.java
@@ -27,8 +27,8 @@ package org.spongepowered.mod.item.merchant;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-
 import net.minecraft.village.MerchantRecipe;
+
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.merchant.TradeOffer;
 import org.spongepowered.api.item.merchant.TradeOfferBuilder;
@@ -44,6 +44,11 @@ public class SpongeTradeOfferBuilder implements TradeOfferBuilder {
 
     public SpongeTradeOfferBuilder() {
         reset();
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/api/text/MixinText.java
+++ b/src/main/java/org/spongepowered/mod/mixin/api/text/MixinText.java
@@ -61,6 +61,10 @@ public abstract class MixinText implements SpongeText {
         throw new UnsupportedOperationException();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private void initializeComponent() {
         if (this.component == null) {
             this.component = createComponent();

--- a/src/main/java/org/spongepowered/mod/mixin/api/text/MixinTextLiteral.java
+++ b/src/main/java/org/spongepowered/mod/mixin/api/text/MixinTextLiteral.java
@@ -40,4 +40,8 @@ public abstract class MixinTextLiteral extends MixinText {
         return new ChatComponentText(this.content);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/api/text/MixinTextScore.java
+++ b/src/main/java/org/spongepowered/mod/mixin/api/text/MixinTextScore.java
@@ -45,4 +45,8 @@ public abstract class MixinTextScore extends MixinText {
         }
         return component;
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/api/text/MixinTextSelector.java
+++ b/src/main/java/org/spongepowered/mod/mixin/api/text/MixinTextSelector.java
@@ -39,4 +39,8 @@ public abstract class MixinTextSelector extends MixinText {
     protected ChatComponentStyle createComponent() {
         return new ChatComponentSelector(this.selector.toPlain());
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/api/text/MixinTextTranslatable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/api/text/MixinTextTranslatable.java
@@ -57,4 +57,8 @@ public abstract class MixinTextTranslatable extends MixinText {
         return ret;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/api/text/title/MixinTitle.java
+++ b/src/main/java/org/spongepowered/mod/mixin/api/text/title/MixinTitle.java
@@ -49,6 +49,10 @@ public abstract class MixinTitle implements SpongeTitle {
 
     private S45PacketTitle[] packets;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void send(EntityPlayerMP player) {
         if (this.packets == null) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/MixinBehaviorProjectileDispense.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/MixinBehaviorProjectileDispense.java
@@ -51,4 +51,8 @@ public class MixinBehaviorProjectileDispense extends BehaviorDefaultDispenseItem
         return world.spawnEntityInWorld(entity);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/MixinBlockState.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/MixinBlockState.java
@@ -60,6 +60,10 @@ public abstract class MixinBlockState extends BlockStateBase implements org.spon
         return this.properties;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public Collection<String> getPropertyNames() {

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/MixinBlockType.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/MixinBlockType.java
@@ -25,11 +25,13 @@
 package org.spongepowered.mod.mixin.core.block;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFalling;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.Item;
+
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.item.ItemBlock;
@@ -64,6 +66,10 @@ public abstract class MixinBlockType implements BlockType {
 
     @Shadow
     public abstract IBlockState getStateFromMeta(int meta);
+    
+    // The legend, the hero, the god
+    @Shadow(prefix = "shadow$")
+    public abstract boolean shadow$isFlowerPot();
 
     @Override
     public String getId() {
@@ -125,6 +131,11 @@ public abstract class MixinBlockType implements BlockType {
     @Override
     public Optional<ItemBlock> getHeldItem() {
         return Optional.fromNullable((ItemBlock) Item.getItemFromBlock((Block) (Object) this));
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return shadow$isFlowerPot();
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/MixinPropertyDirection.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/MixinPropertyDirection.java
@@ -58,6 +58,10 @@ public abstract class MixinPropertyDirection extends PropertyEnum implements Blo
         return getName(getFacing(value));
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public Optional<Direction> getValueForName(String name) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntity.java
@@ -55,9 +55,6 @@ public abstract class MixinTileEntity implements TileEntity {
     @Shadow
     public abstract void markDirty();
 
-    @Shadow(remap = false)
-    public abstract NBTTagCompound getTileData();
-
     @Override
     public Location getBlock() {
         return new Location((World) this.worldObj, VecHelper.toVector(this.getPos()).toDouble());
@@ -119,7 +116,7 @@ public abstract class MixinTileEntity implements TileEntity {
      * @return The data tag
      */
     public final NBTTagCompound getSpongeData() {
-        NBTTagCompound data = this.getTileData();
+        NBTTagCompound data = null;
         if (!data.hasKey("SpongeData", Constants.NBT.TAG_COMPOUND)) {
             data.setTag("SpongeData", new NBTTagCompound());
         }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBanner.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBanner.java
@@ -27,10 +27,12 @@ package org.spongepowered.mod.mixin.core.block.data;
 import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 
 import com.google.common.collect.Lists;
+
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+
 import org.spongepowered.api.GameRegistry;
 import org.spongepowered.api.block.tile.TileEntityType;
 import org.spongepowered.api.block.tile.TileEntityTypes;
@@ -107,6 +109,11 @@ public abstract class MixinTileEntityBanner extends MixinTileEntity {
         container.set(of("Patterns"), Lists.newArrayList(this.patternLayers));
         container.set(of("Base"), this.baseColor);
         return container;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBeacon.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBeacon.java
@@ -27,10 +27,12 @@ package org.spongepowered.mod.mixin.core.block.data;
 import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.inventory.IInventory;
 import net.minecraft.potion.Potion;
 import net.minecraft.server.gui.IUpdatePlayerListBox;
 import net.minecraft.tileentity.TileEntityLockable;
+
 import org.spongepowered.api.block.tile.TileEntityType;
 import org.spongepowered.api.block.tile.TileEntityTypes;
 import org.spongepowered.api.block.tile.carrier.Beacon;
@@ -59,5 +61,10 @@ public abstract class MixinTileEntityBeacon extends MixinTileEntityLockable {
         container.set(of("effect1"), getField(1));
         container.set(of("effect2"), getField(2));
         return container;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBrewingStand.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityBrewingStand.java
@@ -52,4 +52,9 @@ public abstract class MixinTileEntityBrewingStand extends MixinTileEntityLockabl
         }
         return container;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityChest.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityChest.java
@@ -51,4 +51,9 @@ public abstract class MixinTileEntityChest extends MixinTileEntityLockable {
         }
         return container;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityCommandBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityCommandBlock.java
@@ -27,8 +27,10 @@ package org.spongepowered.mod.mixin.core.block.data;
 import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.command.server.CommandBlockLogic;
 import net.minecraft.util.IChatComponent;
+
 import org.spongepowered.api.block.tile.CommandBlock;
 import org.spongepowered.api.service.persistence.data.DataContainer;
 import org.spongepowered.api.service.persistence.data.DataQuery;
@@ -68,5 +70,10 @@ public abstract class MixinTileEntityCommandBlock extends MixinTileEntity {
 //            }
         }
         return container;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityComparator.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityComparator.java
@@ -35,4 +35,9 @@ import org.spongepowered.asm.mixin.Mixin;
 @Mixin(net.minecraft.tileentity.TileEntityComparator.class)
 public abstract class MixinTileEntityComparator extends MixinTileEntity {
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDaylightDetector.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDaylightDetector.java
@@ -35,4 +35,9 @@ import org.spongepowered.asm.mixin.Mixin;
 @Mixin(net.minecraft.tileentity.TileEntityDaylightDetector.class)
 public abstract class MixinTileEntityDaylightDetector extends MixinTileEntity {
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDispenser.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDispenser.java
@@ -35,4 +35,9 @@ import org.spongepowered.asm.mixin.Mixin;
 @Mixin(net.minecraft.tileentity.TileEntityDispenser.class)
 public abstract class MixinTileEntityDispenser extends MixinTileEntityLockable {
 
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDropper.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityDropper.java
@@ -35,4 +35,9 @@ import org.spongepowered.asm.mixin.Mixin;
 @Mixin(net.minecraft.tileentity.TileEntityDropper.class)
 public abstract class MixinTileEntityDropper extends MixinTileEntityLockable {
 
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEnchantmentTable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEnchantmentTable.java
@@ -49,4 +49,9 @@ public abstract class MixinTileEntityEnchantmentTable extends MixinTileEntity {
         container.set(of("CustomName"), this.customName);
         return container;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEndPortal.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEndPortal.java
@@ -35,4 +35,9 @@ import org.spongepowered.asm.mixin.Mixin;
 @Mixin(net.minecraft.tileentity.TileEntityEndPortal.class)
 public abstract class MixinTileEntityEndPortal extends MixinTileEntity {
 
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEnderChest.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityEnderChest.java
@@ -35,4 +35,9 @@ import org.spongepowered.asm.mixin.Mixin;
 @Mixin(net.minecraft.tileentity.TileEntityEnderChest.class)
 public abstract class MixinTileEntityEnderChest extends MixinTileEntity {
 
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityFurnace.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityFurnace.java
@@ -54,4 +54,9 @@ public abstract class MixinTileEntityFurnace extends MixinTileEntityLockable {
         }
         return container;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityHopper.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityHopper.java
@@ -55,4 +55,9 @@ public abstract class MixinTileEntityHopper extends MixinTileEntityLockable {
         }
         return container;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return transferCooldown == 0;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityLockable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityLockable.java
@@ -27,9 +27,11 @@ package org.spongepowered.mod.mixin.core.block.data;
 import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 
 import com.google.common.collect.Lists;
+
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.LockCode;
+
 import org.spongepowered.api.block.tile.carrier.TileEntityCarrier;
 import org.spongepowered.api.service.persistence.data.DataContainer;
 import org.spongepowered.api.service.persistence.data.DataView;
@@ -68,5 +70,10 @@ public abstract class MixinTileEntityLockable extends MixinTileEntity implements
         }
         container.set(of("Contents"), items);
         return container;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityMobSpawner.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityMobSpawner.java
@@ -27,7 +27,9 @@ package org.spongepowered.mod.mixin.core.block.data;
 import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 
 import com.google.common.collect.Lists;
+
 import net.minecraft.tileentity.MobSpawnerBaseLogic;
+
 import org.spongepowered.api.block.tile.MobSpawner;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.service.persistence.data.DataContainer;
@@ -66,6 +68,11 @@ public abstract class MixinTileEntityMobSpawner extends MixinTileEntity {
         } else {
             getSpawnerBaseLogic().spawnDelay = 0;
         }
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
 //    @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityNote.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntityNote.java
@@ -53,4 +53,9 @@ public abstract class MixinTileEntityNote extends MixinTileEntity {
         container.set(of("Note"), this.note);
         return container;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntitySign.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntitySign.java
@@ -28,7 +28,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 
 import com.google.common.collect.Lists;
+
 import net.minecraft.util.IChatComponent;
+
 import org.spongepowered.api.block.tile.Sign;
 import org.spongepowered.api.service.persistence.data.DataContainer;
 import org.spongepowered.api.service.persistence.data.DataQuery;
@@ -62,5 +64,10 @@ public abstract class MixinTileEntitySign extends MixinTileEntity {
 //        }
         container.set(of("Lines"), lines);
         return container;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntitySkull.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/data/MixinTileEntitySkull.java
@@ -27,7 +27,9 @@ package org.spongepowered.mod.mixin.core.block.data;
 import static org.spongepowered.api.service.persistence.data.DataQuery.of;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.tileentity.TileEntity;
+
 import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.block.tile.Skull;
 import org.spongepowered.api.block.tile.data.SkullType;
@@ -68,5 +70,10 @@ public abstract class MixinTileEntitySkull extends MixinTileEntity {
     public DataContainer toContainer() {
         DataContainer container = super.toContainer();
         return container;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/block/meta/MixinEnumBannerPattern.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/block/meta/MixinEnumBannerPattern.java
@@ -49,4 +49,9 @@ public class MixinEnumBannerPattern implements BannerPatternShape {
         return this.patternID;
     }
 
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/command/MixinCommandBlockLogic.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/command/MixinCommandBlockLogic.java
@@ -25,8 +25,10 @@
 package org.spongepowered.mod.mixin.core.command;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.server.CommandBlockLogic;
+
 import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.SubjectCollection;
@@ -67,6 +69,11 @@ public abstract class MixinCommandBlockLogic implements ICommandSender, CommandB
         for (Text message : messages) {
             addChatMessage(((SpongeText) message).toComponent());
         }
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/command/MixinCommandExecuteAtSender.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/command/MixinCommandExecuteAtSender.java
@@ -25,7 +25,9 @@
 package org.spongepowered.mod.mixin.core.command;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.command.ICommandSender;
+
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.SubjectCollection;
 import org.spongepowered.api.service.permission.SubjectData;
@@ -59,6 +61,11 @@ public abstract class MixinCommandExecuteAtSender implements CommandSource, ICom
         for (Text message : messages) {
             addChatMessage(((SpongeText) message).toComponent());
         }
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/command/MixinSubject.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/command/MixinSubject.java
@@ -25,10 +25,12 @@
 package org.spongepowered.mod.mixin.core.command;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.server.CommandBlockLogic;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
+
 import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.SubjectCollection;
@@ -43,6 +45,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.mod.SpongeMod;
 import org.spongepowered.mod.command.MinecraftCommandWrapper;
 import org.spongepowered.mod.interfaces.Subjectable;
+
 
 
 import java.util.Collections;
@@ -73,6 +76,11 @@ public abstract class MixinSubject implements CommandSource, ICommandSender {
             }
         }
         return this.thisSubject;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntity.java
@@ -26,6 +26,7 @@ package org.spongepowered.mod.mixin.core.entity;
 
 import com.flowpowered.math.vector.Vector3d;
 import com.google.common.base.Optional;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
@@ -35,6 +36,7 @@ import net.minecraft.network.play.server.S1FPacketSetExperience;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.util.Constants;
+
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.entity.EntityType;
@@ -71,6 +73,11 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
 
     @Shadow
     private UUID entityUniqueID;
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 
     @Shadow
     public net.minecraft.world.World worldObj;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityEnderCrystal.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityEnderCrystal.java
@@ -27,6 +27,7 @@ package org.spongepowered.mod.mixin.core.entity;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityEnderCrystal;
 import net.minecraft.world.World;
+
 import org.spongepowered.api.entity.EnderCrystal;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
@@ -37,5 +38,10 @@ public abstract class MixinEntityEnderCrystal extends Entity implements EnderCry
 
     public MixinEntityEnderCrystal(World worldIn) {
         super(worldIn);
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityFallingBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityFallingBlock.java
@@ -28,6 +28,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityFallingBlock;
 import net.minecraft.world.World;
+
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.entity.FallingBlock;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -55,6 +56,11 @@ public abstract class MixinEntityFallingBlock extends Entity implements FallingB
 
     public MixinEntityFallingBlock(World worldIn) {
         super(worldIn);
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityItem.java
@@ -25,8 +25,10 @@
 package org.spongepowered.mod.mixin.core.entity;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.nbt.NBTTagCompound;
+
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.api.entity.Item;
 import org.spongepowered.api.entity.player.User;
@@ -58,6 +60,11 @@ public abstract class MixinEntityItem extends MixinEntity implements Item {
 
     @Shadow(remap = false)
     public int lifespan;
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 
     @Shadow
     public abstract net.minecraft.item.ItemStack getEntityItem();

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityXPOrb.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/MixinEntityXPOrb.java
@@ -27,6 +27,7 @@ package org.spongepowered.mod.mixin.core.entity;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.world.World;
+
 import org.spongepowered.api.entity.ExperienceOrb;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
@@ -51,6 +52,11 @@ public abstract class MixinEntityXPOrb extends Entity implements ExperienceOrb {
     @Override
     public void setExperience(int experience) {
         this.xpValue = experience;
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/explosive/MixinEntityTNTPrimed.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/explosive/MixinEntityTNTPrimed.java
@@ -25,9 +25,11 @@
 package org.spongepowered.mod.mixin.core.entity.explosive;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.world.World;
+
 import org.spongepowered.api.entity.explosive.PrimedTNT;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -55,6 +57,11 @@ public abstract class MixinEntityTNTPrimed extends Entity implements PrimedTNT {
     public void detonate() {
         super.setDead();
         this.explode();
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/MixinEntityHanging.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/MixinEntityHanging.java
@@ -28,6 +28,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
+
 import org.spongepowered.api.entity.hanging.Hanging;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -57,6 +58,11 @@ public abstract class MixinEntityHanging extends Entity implements Hanging {
 
     public MixinEntityHanging(World worldIn) {
         super(worldIn);
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     private boolean ignorePhysics = false;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/MixinEntityItemFrame.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/MixinEntityItemFrame.java
@@ -25,8 +25,10 @@
 package org.spongepowered.mod.mixin.core.entity.hanging;
 
 import com.google.common.base.Optional;
+
 import net.minecraft.entity.EntityHanging;
 import net.minecraft.world.World;
+
 import org.spongepowered.api.entity.hanging.ItemFrame;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -60,6 +62,11 @@ public abstract class MixinEntityItemFrame extends EntityHanging implements Item
     @Override
     public Optional<ItemStack> getItem() {
         return Optional.fromNullable((ItemStack) getDisplayedItem());
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/MixinEntityLeashKnot.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/MixinEntityLeashKnot.java
@@ -26,6 +26,7 @@ package org.spongepowered.mod.mixin.core.entity.hanging;
 
 import net.minecraft.entity.EntityHanging;
 import net.minecraft.world.World;
+
 import org.spongepowered.api.entity.hanging.LeashHitch;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
@@ -36,5 +37,10 @@ public abstract class MixinEntityLeashKnot extends EntityHanging implements Leas
 
     public MixinEntityLeashKnot(World worldIn) {
         super(worldIn);
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/MixinEntityPainting.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/MixinEntityPainting.java
@@ -27,6 +27,7 @@ package org.spongepowered.mod.mixin.core.entity.hanging;
 import net.minecraft.entity.EntityHanging;
 import net.minecraft.entity.item.EntityPainting.EnumArt;
 import net.minecraft.world.World;
+
 import org.spongepowered.api.entity.hanging.Painting;
 import org.spongepowered.api.entity.hanging.art.Art;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
@@ -42,6 +43,11 @@ public abstract class MixinEntityPainting extends EntityHanging implements Paint
 
     public MixinEntityPainting(World worldIn) {
         super(worldIn);
+    }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/art/MixinEnumArt.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/hanging/art/MixinEnumArt.java
@@ -56,4 +56,9 @@ public class MixinEnumArt implements Art {
     public String getName() {
         return this.title;
     }
+
+    @Override
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinArmorStand.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinArmorStand.java
@@ -25,9 +25,11 @@
 package org.spongepowered.mod.mixin.core.entity.living;
 
 import com.flowpowered.math.vector.Vector3d;
+
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.util.Rotations;
+
 import org.spongepowered.api.entity.living.ArmorStand;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -116,6 +118,10 @@ public abstract class MixinArmorStand extends EntityLivingBase {
 
     public void astand$setLeftArmDirection(Vector3d direction) {
         setLeftArmRotation(VecHelper.toRotation(direction));
+    }
+
+    public boolean isFlowerPot() {
+        return false;
     }
 
     public Vector3d astand$getRightArmDirection() {

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityAgeable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityAgeable.java
@@ -52,6 +52,10 @@ public abstract class MixinEntityAgeable extends EntityCreature {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public int ageable$getAge() {
         return getGrowingAge();
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityBat.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityBat.java
@@ -49,6 +49,10 @@ public abstract class MixinEntityBat extends EntityAmbientCreature {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public boolean bat$isAwake() {
         return !getIsBatHanging();
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityLiving.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityLiving.java
@@ -62,6 +62,10 @@ public abstract class MixinEntityLiving extends EntityLivingBase {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public boolean agent$isAiEnabled() {
         return !isAIDisabled();
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/MixinEntityLivingBase.java
@@ -103,6 +103,10 @@ public abstract class MixinEntityLivingBase extends Entity {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public void living$damage(double amount) {
         Living thisEntity = (Living) this;
         DamageSource source = DamageSource.generic;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityAnimal.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityAnimal.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityAnimal extends EntityAgeable {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityChicken.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityChicken.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityChicken extends EntityAnimal {
         super(worldIn);
     }
 
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityCow.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityCow.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityCow extends EntityAnimal {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityHorse.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityHorse.java
@@ -97,6 +97,10 @@ public abstract class MixinEntityHorse extends EntityAnimal {
         return Optional.fromNullable((ItemStack) this.horseChest.getStackInSlot(0));
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public void setSaddle(@Nullable ItemStack itemStack) {
         net.minecraft.item.ItemStack nmsStack = (net.minecraft.item.ItemStack) itemStack;
         if (nmsStack != null && nmsStack.getItem() == Items.saddle) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityMooshroom.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityMooshroom.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityMooshroom extends EntityCow {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityOcelot.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityOcelot.java
@@ -60,4 +60,8 @@ public abstract class MixinEntityOcelot extends EntityTameable {
         this.setTameSkin(((SpongeEntityMeta) ocelotType).type);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityPig.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityPig.java
@@ -53,4 +53,8 @@ public abstract class MixinEntityPig extends EntityAnimal {
             this.dataWatcher.updateObject(16, (byte) 0);
         }
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityRabbit.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityRabbit.java
@@ -60,4 +60,8 @@ public abstract class MixinEntityRabbit extends EntityAnimal {
         this.shadow$setRabbitType(((SpongeEntityMeta) type).type);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntitySheep.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntitySheep.java
@@ -60,4 +60,8 @@ public abstract class MixinEntitySheep extends EntityAnimal {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntitySquid.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntitySquid.java
@@ -42,4 +42,8 @@ public abstract class MixinEntitySquid extends EntityWaterMob {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityWolf.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/animal/MixinEntityWolf.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityWolf extends EntityTameable {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/complex/MixinEntityDragon.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/complex/MixinEntityDragon.java
@@ -78,4 +78,8 @@ public abstract class MixinEntityDragon extends EntityLiving {
         this.healingEnderCrystal = (EntityEnderCrystal) crystal;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/complex/MixinEntityDragonPart.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/complex/MixinEntityDragonPart.java
@@ -52,4 +52,8 @@ public abstract class MixinEntityDragonPart extends Entity {
         return (EnderDragon) this.entityDragonObj;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/golem/MixinEntityGolem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/golem/MixinEntityGolem.java
@@ -42,4 +42,8 @@ public class MixinEntityGolem extends EntityCreature {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/golem/MixinEntityIronGolem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/golem/MixinEntityIronGolem.java
@@ -56,4 +56,8 @@ public abstract class MixinEntityIronGolem extends EntityGolem {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/golem/MixinEntitySnowman.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/golem/MixinEntitySnowman.java
@@ -42,4 +42,8 @@ public abstract class MixinEntitySnowman extends EntityGolem {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityBlaze.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityBlaze.java
@@ -57,4 +57,8 @@ public abstract class MixinEntityBlaze extends EntityMob {
     public void blaze$setOnFire(boolean onFire) {
         this.func_70844_e(onFire);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityCaveSpider.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityCaveSpider.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityCaveSpider extends EntitySpider {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityCreeper.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityCreeper.java
@@ -69,6 +69,10 @@ public abstract class MixinEntityCreeper extends EntityMob {
         this.ignite();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public void creeper$ignite(int fuseTicks) {
         this.timeSinceIgnited = 0;
         this.fuseTime = fuseTicks;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityEnderman.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityEnderman.java
@@ -62,4 +62,8 @@ public abstract class MixinEntityEnderman extends EntityMob {
     public void enderman$setScreaming(boolean screaming) {
         this.dataWatcher.updateObject(18, (byte) (screaming ? 1 : 0));
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityEndermite.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityEndermite.java
@@ -53,4 +53,8 @@ public abstract class MixinEntityEndermite extends EntityMob {
     public void endermite$setPlayerCreated(boolean playerCreated) {
         this.playerSpawned = playerCreated;
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityGhast.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityGhast.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityGhast extends EntityFlying {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityGiantZombie.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityGiantZombie.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityGiantZombie extends EntityMob {
         super(worldIn);
     }
 
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityGuardian.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityGuardian.java
@@ -59,4 +59,8 @@ public abstract class MixinEntityGuardian extends EntityMob {
     public void guardian$setElder(boolean elder) {
         this.setElder(elder);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityMagmaCube.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityMagmaCube.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityMagmaCube extends EntitySlime {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityMob.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityMob.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityMob extends EntityCreature {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityPigZombie.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityPigZombie.java
@@ -54,4 +54,8 @@ public abstract class MixinEntityPigZombie extends EntityZombie {
         this.angerLevel = angerLevel;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntitySilverfish.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntitySilverfish.java
@@ -42,4 +42,8 @@ public abstract class MixinEntitySilverfish extends EntityMob {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntitySkeleton.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntitySkeleton.java
@@ -57,4 +57,8 @@ public abstract class MixinEntitySkeleton extends EntityMob {
         this.setSkeletonType(((SpongeEntityMeta) skeletonType).type);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntitySlime.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntitySlime.java
@@ -56,4 +56,8 @@ public abstract class MixinEntitySlime extends EntityLiving {
     public void slime$setSize(int size) {
         setSlimeSize(size);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntitySpider.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntitySpider.java
@@ -50,4 +50,8 @@ public abstract class MixinEntitySpider extends EntityMob {
         return this.isBesideClimbableBlock();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityWitch.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityWitch.java
@@ -54,4 +54,8 @@ public abstract class MixinEntityWitch extends EntityMob {
         this.getDataWatcher().updateObject(21, (byte) (aggressive ? 1 : 0));
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityWither.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityWither.java
@@ -65,6 +65,10 @@ public abstract class MixinEntityWither extends EntityMob {
         this.setInvulTime(invulnerableTicks);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public List<Living> wither$getTargets() {
         List<Living> watchedTargets = new ArrayList<Living>();
         for (int i = 0; i < 2; ++i) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityZombie.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/monster/MixinEntityZombie.java
@@ -59,6 +59,10 @@ public abstract class MixinEntityZombie extends EntityMob {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public boolean zombie$isVillagerZombie() {
         return this.isVillager();
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/living/villager/MixinEntityVillager.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/living/villager/MixinEntityVillager.java
@@ -133,6 +133,10 @@ public abstract class MixinEntityVillager extends EntityAgeable {
         return getRecipes(null);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @SuppressWarnings("unchecked")
     public void villager$addOffer(TradeOffer offer) {
         this.buyingList.add(offer);

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/player/MixinEntityPlayer.java
@@ -87,6 +87,10 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
         return this.getFoodStats().getFoodLevel();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public void human$setFoodLevel(double hunger) {
         this.getFoodStats().setFoodLevel((int) hunger);
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -124,6 +124,10 @@ public abstract class MixinEntityPlayerMP extends EntityPlayer implements Comman
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public void playermp$sendMessage(ChatType type, Iterable<Text> messages) {
         for (Text text : messages) {
             this.playerNetServerHandler.sendPacket(new S02PacketChat(((SpongeText) text).toComponent(), ((SpongeChatType) type).getId()));

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityArrow.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityArrow.java
@@ -75,6 +75,10 @@ public abstract class MixinEntityArrow extends MixinEntity implements Arrow {
         return new UnknownProjectileSource();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void setShooter(ProjectileSource shooter) {
         if (shooter instanceof Entity) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEgg.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEgg.java
@@ -63,6 +63,10 @@ public abstract class MixinEntityEgg extends MixinEntityThrowable {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEnderEye.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEnderEye.java
@@ -65,6 +65,10 @@ public abstract class MixinEntityEnderEye extends MixinEntity implements EyeOfEn
         this.targetZ = vector3d.getZ();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean doesShatterOnDrop() {
         return !this.shatterOrDrop;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEnderPearl.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityEnderPearl.java
@@ -64,6 +64,10 @@ public abstract class MixinEntityEnderPearl extends MixinEntityThrowable {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityExpBottle.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityExpBottle.java
@@ -41,4 +41,8 @@ public abstract class MixinEntityExpBottle extends EntityThrowable {
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityFireworkRocket.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityFireworkRocket.java
@@ -51,6 +51,10 @@ public abstract class MixinEntityFireworkRocket extends MixinEntity implements F
         return this.lifetime - this.fireworkAge;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void setFuseDuration(int fuseTicks) {
         this.lifetime = fuseTicks + this.fireworkAge;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityFishHook.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityFishHook.java
@@ -87,6 +87,10 @@ public abstract class MixinEntityFishHook extends Entity implements FishHook, IM
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public ProjectileSource getShooter() {
         if (this.projectileSource != null) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityPotion.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityPotion.java
@@ -63,4 +63,8 @@ public abstract class MixinEntityPotion extends EntityThrowable {
         return Items.potionitem.getEffects(this.potionDamage);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntitySnowball.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntitySnowball.java
@@ -65,6 +65,10 @@ public abstract class MixinEntitySnowball extends MixinEntityThrowable {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityThrowable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/MixinEntityThrowable.java
@@ -66,6 +66,10 @@ public abstract class MixinEntityThrowable extends MixinEntity implements Projec
         return new UnknownProjectileSource();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void setShooter(ProjectileSource shooter) {
         if (shooter instanceof EntityLivingBase) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityFireball.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityFireball.java
@@ -61,6 +61,10 @@ public abstract class MixinEntityFireball extends MixinEntity implements Firebal
         return this.projectileSource;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void setShooter(ProjectileSource shooter) {
         this.projectileSource = shooter;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityLargeFireball.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityLargeFireball.java
@@ -52,6 +52,10 @@ public abstract class MixinEntityLargeFireball extends MixinEntityFireball imple
         return this.damage;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void setDamage(double damage) {
         this.damage = (float) damage;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntitySmallFireball.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntitySmallFireball.java
@@ -48,6 +48,10 @@ public abstract class MixinEntitySmallFireball extends MixinEntityFireball imple
         return this.damage;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void setDamage(double damage) {
         this.damage = (float) damage;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityWitherSkull.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/projectile/fireball/MixinEntityWitherSkull.java
@@ -57,6 +57,10 @@ public abstract class MixinEntityWitherSkull extends MixinEntityFireball impleme
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void setDamage(double damage) {
         this.damageSet = true;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/MixinEntityBoat.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/MixinEntityBoat.java
@@ -66,6 +66,10 @@ public abstract class MixinEntityBoat extends Entity implements Boat {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Inject(method = "onUpdate()V", at = @At(value = "INVOKE", target = "java.lang.Math.sqrt(D)D", ordinal = 0))
     public void beforeModifyMotion(CallbackInfo ci) {
         this.initialDisplacement = Math.sqrt(this.motionX * this.motionX + this.motionZ * this.motionZ);

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecart.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecart.java
@@ -63,6 +63,10 @@ public abstract class MixinEntityMinecart extends Entity implements Minecart {
         return this.maxSpeed;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     // this method overwrites vanilla behavior to allow for a custom deceleration rate on all three axes when airborne
     @Inject(method = "moveDerailedMinecart()V", at = @At(value = "FIELD", target = "net.minecraft.entity.Entity.onGround:Z", ordinal = 2))
     public void implementCustomAirborneDeceleration(CallbackInfo ci) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartChest.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartChest.java
@@ -39,4 +39,8 @@ public abstract class MixinEntityMinecartChest extends EntityMinecart implements
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartCommandBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartCommandBlock.java
@@ -47,6 +47,10 @@ public abstract class MixinEntityMinecartCommandBlock extends EntityMinecart imp
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public String getCommand() {
         return this.commandBlockLogic.getCommandSenderName();

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartContainer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartContainer.java
@@ -39,4 +39,8 @@ public abstract class MixinEntityMinecartContainer extends EntityMinecart implem
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartFurnace.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartFurnace.java
@@ -52,4 +52,8 @@ public abstract class MixinEntityMinecartFurnace extends EntityMinecart implemen
     public void setFuel(int fuel) {
         this.fuel = fuel;
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartMobSpawner.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartMobSpawner.java
@@ -39,4 +39,8 @@ public abstract class MixinEntityMinecartMobSpawner extends EntityMinecart imple
         super(worldIn);
     }
 
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartRideable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartRideable.java
@@ -39,4 +39,8 @@ public abstract class MixinEntityMinecartRideable extends EntityMinecart impleme
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartTNT.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/vehicle/minecart/MixinEntityMinecartTNT.java
@@ -39,4 +39,8 @@ public abstract class MixinEntityMinecartTNT extends EntityMinecart implements M
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/weather/MixinEntityLightningBolt.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/weather/MixinEntityLightningBolt.java
@@ -47,6 +47,10 @@ public abstract class MixinEntityLightningBolt extends EntityWeatherEffect imple
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean isEffect() {
         return this.effect;

--- a/src/main/java/org/spongepowered/mod/mixin/core/entity/weather/MixinEntityWeatherEffect.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/entity/weather/MixinEntityWeatherEffect.java
@@ -38,4 +38,8 @@ public abstract class MixinEntityWeatherEffect extends Entity implements Weather
         super(worldIn);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/MixinEvent.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/MixinEvent.java
@@ -56,6 +56,10 @@ public abstract class MixinEvent implements GameEvent, CauseTracked, Cancellable
         return Optional.fromNullable(new Cause(null, Optional.absent(), null));
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean isCancelled() {
         return isCanceled();

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/MixinEventBus.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/MixinEventBus.java
@@ -48,6 +48,10 @@ public abstract class MixinEventBus {
     @Shadow
     private IEventExceptionHandler exceptionHandler;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Overwrite
     public boolean post(Event event) {
         IEventListener[] listeners = event.getListenerList().getListeners(this.busID);

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/block/MixinBlockUpdateEvent.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/block/MixinBlockUpdateEvent.java
@@ -55,6 +55,10 @@ public abstract class MixinBlockUpdateEvent extends BlockEvent implements BlockU
         this.notifiedSides = notifiedSides;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Collection<Location> getAffectedBlocks() {
         if (this.affectedBlocks == null) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/block/MixinEventBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/block/MixinEventBlock.java
@@ -58,6 +58,10 @@ public abstract class MixinEventBlock extends Event implements BlockEvent {
         return Optional.of(new Cause(null, getBlock(), null));
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Game getGame() {
         return SpongeMod.instance.getGame();

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/entity/MixinEventEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/entity/MixinEventEntity.java
@@ -49,4 +49,8 @@ public abstract class MixinEventEntity extends Event implements EntityEvent {
     public Game getGame() {
         return SpongeMod.instance.getGame();
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/entity/MixinEventEntityConstructing.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/entity/MixinEventEntityConstructing.java
@@ -37,4 +37,8 @@ public abstract class MixinEventEntityConstructing extends EntityEvent implement
     public MixinEventEntityConstructing(Entity entity) {
         super(entity);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/entity/MixinEventEntityJoinWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/entity/MixinEventEntityJoinWorld.java
@@ -43,4 +43,8 @@ public abstract class MixinEventEntityJoinWorld extends EntityEvent implements E
     public Location getLocation() {
         return getEntity().getLocation();
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/entity/living/MixinEventLiving.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/entity/living/MixinEventLiving.java
@@ -51,4 +51,8 @@ public abstract class MixinEventLiving extends EntityEvent implements LivingEven
     public Living getEntity() {
         return (Living) this.entityLiving;
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/inventory/MixinEventItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/inventory/MixinEventItem.java
@@ -52,4 +52,8 @@ public abstract class MixinEventItem extends EntityEvent implements ItemEvent {
     public Item getEntity() {
         return (Item) this.entityItem;
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayer.java
@@ -64,4 +64,8 @@ public abstract class MixinEventPlayer extends LivingEvent implements PlayerEven
         return (Player) this.entityPlayer;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerBreakBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerBreakBlock.java
@@ -65,6 +65,10 @@ public abstract class MixinEventPlayerBreakBlock extends BlockEvent implements P
         return (Player) this.player;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public BlockSnapshot getReplacementBlock() {
         return (BlockSnapshot) this.blockSnapshot;

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerChat.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerChat.java
@@ -62,6 +62,10 @@ public abstract class MixinEventPlayerChat extends Event implements PlayerChatEv
         return ((SpongeChatComponent) this.component).toText();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Player getPlayer() {
         return (Player) this.player;

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerDropItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerDropItem.java
@@ -64,6 +64,10 @@ public abstract class MixinEventPlayerDropItem extends ItemEvent implements Play
         return (Player) this.player;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Player getLiving() {
         return (Player) this.player;

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerFML.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerFML.java
@@ -62,6 +62,10 @@ public abstract class MixinEventPlayerFML extends Event implements PlayerEvent {
         return (Player) this.player;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Player getEntity() {
         return (Player) this.player;

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerInteractBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerInteractBlock.java
@@ -74,6 +74,10 @@ public abstract class MixinEventPlayerInteractBlock extends PlayerEvent implemen
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Optional<Cause> getCause() {
         return Optional.fromNullable(new Cause(null, this.entityPlayer, null));

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerJoin.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerJoin.java
@@ -44,4 +44,8 @@ public abstract class MixinEventPlayerJoin implements PlayerJoinEvent {
     @Override
     public void setJoinMessage(Text joinMessage) {
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerPlaceBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerPlaceBlock.java
@@ -62,6 +62,10 @@ public abstract class MixinEventPlayerPlaceBlock extends BlockEvent implements P
         super(world, pos, state);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Player getPlayer() {
         return (Player) this.player;

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerQuit.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/player/MixinEventPlayerQuit.java
@@ -44,4 +44,8 @@ public abstract class MixinEventPlayerQuit implements PlayerQuitEvent {
     @Override
     public void setQuitMessage(Text joinMessage) {
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventConstruction.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventConstruction.java
@@ -34,4 +34,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(FMLConstructionEvent.class)
 public abstract class MixinEventConstruction extends FMLStateEvent implements ConstructionEvent {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventInit.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventInit.java
@@ -34,4 +34,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(FMLInitializationEvent.class)
 public abstract class MixinEventInit extends FMLStateEvent implements InitializationEvent {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventLoadComplete.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventLoadComplete.java
@@ -34,4 +34,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(FMLLoadCompleteEvent.class)
 public abstract class MixinEventLoadComplete extends FMLStateEvent implements LoadCompleteEvent {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventPostInit.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventPostInit.java
@@ -34,4 +34,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(FMLPostInitializationEvent.class)
 public abstract class MixinEventPostInit extends FMLStateEvent implements PostInitializationEvent {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventPreInit.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventPreInit.java
@@ -34,4 +34,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(value = FMLPreInitializationEvent.class, remap = false)
 public abstract class MixinEventPreInit extends FMLStateEvent implements PreInitializationEvent {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventServerAboutToStart.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventServerAboutToStart.java
@@ -34,4 +34,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(FMLServerAboutToStartEvent.class)
 public abstract class MixinEventServerAboutToStart extends FMLStateEvent implements ServerAboutToStartEvent {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventServerStarted.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventServerStarted.java
@@ -34,4 +34,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(FMLServerStartedEvent.class)
 public abstract class MixinEventServerStarted extends FMLStateEvent implements ServerStartedEvent {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventServerStarting.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventServerStarting.java
@@ -34,4 +34,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(FMLServerStartingEvent.class)
 public abstract class MixinEventServerStarting extends FMLStateEvent implements ServerStartingEvent {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventServerStopped.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventServerStopped.java
@@ -34,4 +34,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(FMLServerStoppedEvent.class)
 public abstract class MixinEventServerStopped extends FMLStateEvent implements ServerStoppedEvent {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventServerStopping.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventServerStopping.java
@@ -34,4 +34,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(FMLServerStoppingEvent.class)
 public abstract class MixinEventServerStopping extends FMLStateEvent implements ServerStoppingEvent {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventState.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/state/MixinEventState.java
@@ -38,4 +38,8 @@ public abstract class MixinEventState extends FMLEvent {
     public Game getGame() {
         return SpongeMod.instance.getGame();
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventChunk.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventChunk.java
@@ -48,4 +48,8 @@ public abstract class MixinEventChunk extends WorldEvent implements ChunkEvent {
         return (Chunk) this.chunk;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventChunkLoad.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventChunkLoad.java
@@ -44,4 +44,8 @@ public abstract class MixinEventChunkLoad extends ChunkEvent {
     public Chunk chunkload$getChunk() {
         return (Chunk) getChunk();
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventChunkUnload.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventChunkUnload.java
@@ -44,4 +44,8 @@ public abstract class MixinEventChunkUnload extends ChunkEvent {
     public Chunk chunkunload$getChunk() {
         return (Chunk) getChunk();
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorld.java
@@ -49,4 +49,8 @@ public abstract class MixinEventWorld extends Event implements WorldEvent {
     public Game getGame() {
         return SpongeMod.instance.getGame();
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorldLoad.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorldLoad.java
@@ -38,4 +38,8 @@ public abstract class MixinEventWorldLoad extends WorldEvent implements WorldLoa
         super(world);
     }
 
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorldUnload.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/event/world/MixinEventWorldUnload.java
@@ -38,4 +38,8 @@ public abstract class MixinEventWorldUnload extends WorldEvent implements WorldU
         super(world);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/fml/MixinEntityRegistry.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/fml/MixinEntityRegistry.java
@@ -60,6 +60,10 @@ public abstract class MixinEntityRegistry implements SpongeEntityRegistry {
     @Shadow
     private BiMap<Class<? extends Entity>, EntityRegistration> entityClassRegistrations;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @SuppressWarnings({"unchecked", "unused"})
     private void doModEntityRegistration(Class<? extends Entity> entityClass, String entityName, int id, Object mod, int trackingRange,
             int updateFrequency, boolean sendsVelocityUpdates) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/fml/MixinModContainer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/fml/MixinModContainer.java
@@ -49,4 +49,8 @@ public abstract class MixinModContainer implements ModContainer, PluginContainer
     public Object getInstance() {
         return getMod();
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/forge/MixinBlockSnapshot.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/forge/MixinBlockSnapshot.java
@@ -43,4 +43,8 @@ public abstract class MixinBlockSnapshot implements BlockSnapshot {
         return (BlockState) this.replacedBlock;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/forge/MixinDimensionManager.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/forge/MixinDimensionManager.java
@@ -46,6 +46,10 @@ public abstract class MixinDimensionManager {
     @Shadow
     private static Hashtable<Integer, Boolean> spawnSettings;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Overwrite
     public static boolean registerProviderType(int id, Class<? extends WorldProvider> provider, boolean keepLoaded) {
         if (providers.containsKey(id)) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/inventory/MixinContainer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/inventory/MixinContainer.java
@@ -62,4 +62,8 @@ public abstract class MixinContainer {
             container.detectAndSendChanges();
         }
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinCookedFish.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinCookedFish.java
@@ -52,4 +52,8 @@ public class MixinCookedFish implements CookedFish {
         container.set(of("CookedFish"), this.getId());
         return container;
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinEnchantment.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinEnchantment.java
@@ -67,6 +67,10 @@ public abstract class MixinEnchantment implements Enchantment {
     @Shadow(remap = false)
     public abstract boolean isAllowedOnBooks();
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Inject(method = "<init>", at = @At("RETURN"))
     public void onConstructed(int id, ResourceLocation resLoc, int weight, EnumEnchantmentType type, CallbackInfo ci) {
         this.id = resLoc.toString();

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinEnumDyeColor.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinEnumDyeColor.java
@@ -62,4 +62,8 @@ public class MixinEnumDyeColor implements DyeColor {
         return container;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinFishType.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinFishType.java
@@ -52,4 +52,8 @@ public class MixinFishType implements Fish {
         container.set(of("FishType"), this.unlocalizedName);
         return container;
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemBlock.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemBlock.java
@@ -43,4 +43,8 @@ public abstract class MixinItemBlock extends Item implements ItemBlock {
     public BlockType getBlock() {
         return (BlockType) shadow$getBlock();
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemEnderEye.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemEnderEye.java
@@ -47,4 +47,8 @@ public class MixinItemEnderEye extends Item {
         return world.spawnEntityInWorld(enderEye);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemFirework.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemFirework.java
@@ -50,4 +50,8 @@ public class MixinItemFirework extends Item {
         return world.spawnEntityInWorld(firework);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemFishingRod.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemFishingRod.java
@@ -67,4 +67,8 @@ public abstract class MixinItemFishingRod extends Item implements IMixinEntityFi
         return itemStack;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemType.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/MixinItemType.java
@@ -59,4 +59,8 @@ public abstract class MixinItemType implements ItemType {
     public int getMaxStackQuantity() {
         return getItemStackLimit();
     }
+
+    public boolean isFlowerPot() {
+        return !getUnlocalizedName().equals("FlowerPot");
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/inventory/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/inventory/MixinItemStack.java
@@ -98,6 +98,10 @@ public abstract class MixinItemStack implements ItemStack {
         shadow$getItem().setMaxStackSize(quantity);
     }
 
+    public boolean isFlowerPot() {
+        return !getItem().isFlowerPot();
+    }
+
     @Override
     public <T extends ItemData<T>> ItemDataTransactionResult setItemData(T itemData) {
         // TODO actually implement this....

--- a/src/main/java/org/spongepowered/mod/mixin/core/item/merchant/MixinMerchantRecipe.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/item/merchant/MixinMerchantRecipe.java
@@ -64,6 +64,10 @@ public abstract class MixinMerchantRecipe implements TradeOffer {
         return (ItemStack) getItemToBuy();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean hasSecondItem() {
         return hasSecondItemToBuy();

--- a/src/main/java/org/spongepowered/mod/mixin/core/potion/MixinPotion.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/potion/MixinPotion.java
@@ -40,4 +40,8 @@ public abstract class MixinPotion implements PotionEffectType {
         return false;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/potion/MixinPotionEffect.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/potion/MixinPotionEffect.java
@@ -63,6 +63,10 @@ public abstract class MixinPotionEffect implements PotionEffect {
         return (PotionEffectType) Potion.potionTypes[getPotionID()];
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public int potionEffect$getDuration() {
         return this.duration;
     }

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinMinecraftServer.java
@@ -111,6 +111,10 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, Sub
         return Optional.absent();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Optional<World> loadWorld(String worldName) {
         throw new UnsupportedOperationException(); // TODO

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinNetHandlerHandshakeTCP.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinNetHandlerHandshakeTCP.java
@@ -47,4 +47,8 @@ public abstract class MixinNetHandlerHandshakeTCP {
         info.setVirtualHost(packetIn.ip, packetIn.port);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinNetHandlerPlayServer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinNetHandlerPlayServer.java
@@ -57,6 +57,10 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
         return (Player) this.playerEntity;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public InetSocketAddress getAddress() {
         return ((ConnectionInfo) this.netManager).getAddress();

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinNetworkManager.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinNetworkManager.java
@@ -55,6 +55,10 @@ public abstract class MixinNetworkManager extends SimpleChannelInboundHandler im
         return this.virtualHost;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void setVirtualHost(String host, int port) {
         this.virtualHost = InetSocketAddress.createUnresolved(host, port);

--- a/src/main/java/org/spongepowered/mod/mixin/core/server/MixinServerCommandManager.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/server/MixinServerCommandManager.java
@@ -68,6 +68,10 @@ public abstract class MixinServerCommandManager extends CommandHandler implement
         this.earlyRegisterCommands = Lists.newArrayList();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public int executeCommand(ICommandSender sender, String command) {
         command = command.trim();

--- a/src/main/java/org/spongepowered/mod/mixin/core/status/MixinMinecraftProtocolVersionIdentifier.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/status/MixinMinecraftProtocolVersionIdentifier.java
@@ -39,6 +39,10 @@ public abstract class MixinMinecraftProtocolVersionIdentifier implements Protoco
     @Shadow
     private int protocol;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public String getName() {
         return this.name;

--- a/src/main/java/org/spongepowered/mod/mixin/core/status/MixinNetHandlerStatusServer.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/status/MixinNetHandlerStatusServer.java
@@ -45,6 +45,10 @@ public abstract class MixinNetHandlerStatusServer {
     @Shadow
     private NetworkManager networkManager;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Overwrite
     public void processServerQuery(C00PacketServerQuery packetIn) {
         // Clone the response

--- a/src/main/java/org/spongepowered/mod/mixin/core/status/MixinPingResponseHandler.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/status/MixinPingResponseHandler.java
@@ -50,6 +50,10 @@ public abstract class MixinPingResponseHandler extends ChannelInboundHandlerAdap
     @Shadow
     private NetworkSystem networkSystem;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private ByteBuf buf;
 
     @Shadow

--- a/src/main/java/org/spongepowered/mod/mixin/core/status/MixinPlayerCountData.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/status/MixinPlayerCountData.java
@@ -46,6 +46,10 @@ public abstract class MixinPlayerCountData implements StatusPingEvent.Response.P
     @Shadow
     private int maxPlayers;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public int getOnline() {
         return this.onlinePlayerCount;

--- a/src/main/java/org/spongepowered/mod/mixin/core/status/MixinServerStatusResponse.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/status/MixinServerStatusResponse.java
@@ -56,6 +56,10 @@ public abstract class MixinServerStatusResponse implements StatusPingEvent.Respo
     private ServerStatusResponse.PlayerCountData playerCount;
     private ServerStatusResponse.PlayerCountData playerBackup;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Shadow
     private ServerStatusResponse.MinecraftProtocolVersionIdentifier protocolVersion;
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatComponentScore.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatComponentScore.java
@@ -37,4 +37,8 @@ public abstract class MixinChatComponentScore extends MixinChatComponentStyle {
         return Texts.builder((Object) null); // TODO
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatComponentSelector.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatComponentSelector.java
@@ -41,4 +41,8 @@ public abstract class MixinChatComponentSelector extends MixinChatComponentStyle
         return Texts.builder(Selectors.parse(this.selector));
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatComponentStyle.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatComponentStyle.java
@@ -57,6 +57,10 @@ public abstract class MixinChatComponentStyle implements SpongeChatComponent {
         throw new UnsupportedOperationException();
     }
 
+
+    public boolean isFlowerPot() {
+        return false;
+    }
     @Override
     public Iterable<IChatComponent> withChildren() {
         if (this.childrenIterable == null) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatComponentText.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatComponentText.java
@@ -40,4 +40,8 @@ public abstract class MixinChatComponentText extends MixinChatComponentStyle {
         return Texts.builder(this.text);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatComponentTranslation.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatComponentTranslation.java
@@ -43,6 +43,10 @@ public abstract class MixinChatComponentTranslation extends MixinChatComponentSt
         return Texts.builder(new SpongeTranslation(this.key), wrapFormatArgs(this.formatArgs));
     }
 
+
+    public boolean isFlowerPot() {
+        return false;
+    }
     private static Object[] wrapFormatArgs(Object... formatArgs) {
         Object[] ret = new Object[formatArgs.length];
         for (int i = 0; i < formatArgs.length; ++i) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatStyle.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatStyle.java
@@ -47,6 +47,10 @@ public abstract class MixinChatStyle implements SpongeChatStyle {
     @Shadow
     public abstract boolean getItalic();
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Shadow
     public abstract boolean getStrikethrough();
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatStyleRoot.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/text/MixinChatStyleRoot.java
@@ -37,4 +37,8 @@ public abstract class MixinChatStyleRoot extends ChatStyle implements SpongeChat
         return ArrayUtils.EMPTY_CHAR_ARRAY;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/text/MixinClickEvent.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/text/MixinClickEvent.java
@@ -45,6 +45,10 @@ public abstract class MixinClickEvent implements SpongeClickEvent {
     private ClickAction<?> handle;
     private boolean initialized;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public ClickAction<?> getHandle() {
         if (!this.initialized) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/text/MixinHoverEvent.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/text/MixinHoverEvent.java
@@ -54,6 +54,10 @@ public abstract class MixinHoverEvent implements SpongeHoverEvent {
     private HoverAction<?> handle;
     private boolean initialized;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public HoverAction<?> getHandle() {
         if (!this.initialized) {

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinChunk.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinChunk.java
@@ -51,6 +51,10 @@ public abstract class MixinChunk implements Chunk {
     @Shadow
     private net.minecraft.world.World worldObj;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Shadow
     public int xPosition;
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorld.java
@@ -112,6 +112,10 @@ public abstract class MixinWorld implements World, IMixinWorld {
     @Shadow
     public abstract boolean spawnEntityInWorld(net.minecraft.entity.Entity entityIn);
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Shadow
     public abstract List<net.minecraft.entity.Entity> getEntities(Class<net.minecraft.entity.Entity> entityType,
             Predicate<net.minecraft.entity.Entity> filter);

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldBorder.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldBorder.java
@@ -51,6 +51,10 @@ public abstract class MixinWorldBorder implements WorldBorder {
     @Shadow
     private double startDiameter;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Shadow
     private double endDiameter;
 

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldProvider.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/MixinWorldProvider.java
@@ -65,6 +65,10 @@ public abstract class MixinWorldProvider implements Dimension, IMixinWorldProvid
     @Shadow
     public abstract boolean getHasNoSky();
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Overwrite
     public static WorldProvider getProviderForDimension(int dimension) {
         WorldProvider provider = net.minecraftforge.common.DimensionManager.createProviderFor(dimension);

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/biome/MixinBiomeGenBase.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/biome/MixinBiomeGenBase.java
@@ -33,4 +33,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @Mixin(BiomeGenBase.class)
 public abstract class MixinBiomeGenBase implements BiomeType {
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/core/world/difficulty/MixinEnumDifficulty.java
+++ b/src/main/java/org/spongepowered/mod/mixin/core/world/difficulty/MixinEnumDifficulty.java
@@ -32,4 +32,8 @@ import org.spongepowered.asm.mixin.Mixin;
 @NonnullByDefault
 @Mixin(net.minecraft.world.EnumDifficulty.class)
 public class MixinEnumDifficulty implements Difficulty {
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntity.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntity.java
@@ -60,6 +60,10 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void inactiveTick() {
     }

--- a/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityAgeable.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityAgeable.java
@@ -55,6 +55,10 @@ public abstract class MixinEntityAgeable extends EntityCreature {
     @Shadow
     public abstract void setScaleForAge(boolean baby);
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @SoftOverride
     public void inactiveTick() {
         this.super$.inactiveTick();

--- a/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityArrow.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityArrow.java
@@ -47,4 +47,8 @@ public abstract class MixinEntityArrow extends MixinEntity implements Arrow {
         }
         super.inactiveTick();
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityFireworkRocket.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityFireworkRocket.java
@@ -42,4 +42,8 @@ public abstract class MixinEntityFireworkRocket extends MixinEntity implements F
         super.inactiveTick();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityItem.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityItem.java
@@ -63,4 +63,8 @@ public abstract class MixinEntityItem extends Entity implements Item {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinEntityLivingBase.java
@@ -46,4 +46,8 @@ public abstract class MixinEntityLivingBase extends MixinEntity {
         ++this.entityAge;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinWorld.java
+++ b/src/main/java/org/spongepowered/mod/mixin/entityactivation/MixinWorld.java
@@ -62,6 +62,10 @@ public abstract class MixinWorld implements World, IMixinWorld {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Overwrite
     public void updateEntityWithOptionalForce(net.minecraft.entity.Entity entity, boolean forceUpdate) {
         int i = MathHelper.floor_double(entity.posX);

--- a/src/main/java/org/spongepowered/mod/mixin/plugin/CoreMixinPlugin.java
+++ b/src/main/java/org/spongepowered/mod/mixin/plugin/CoreMixinPlugin.java
@@ -52,6 +52,10 @@ public class CoreMixinPlugin implements IMixinConfigPlugin {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public String getRefMapperConfig() {
         return null;

--- a/src/main/java/org/spongepowered/mod/mixin/plugin/entityactivation/ActivationRange.java
+++ b/src/main/java/org/spongepowered/mod/mixin/plugin/entityactivation/ActivationRange.java
@@ -94,6 +94,10 @@ public class ActivationRange {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     /**
      * These entities are excluded from Activation range checks.
      *

--- a/src/main/java/org/spongepowered/mod/mixin/plugin/entityactivation/EntityActivationRangePlugin.java
+++ b/src/main/java/org/spongepowered/mod/mixin/plugin/entityactivation/EntityActivationRangePlugin.java
@@ -55,6 +55,10 @@ public class EntityActivationRangePlugin implements IMixinConfigPlugin {
         return true;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
     }

--- a/src/main/java/org/spongepowered/mod/plugin/SpongePluginContainer.java
+++ b/src/main/java/org/spongepowered/mod/plugin/SpongePluginContainer.java
@@ -85,6 +85,10 @@ public class SpongePluginContainer implements ModContainer, PluginContainer {
         this.pluginDescriptor = descriptor;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Subscribe
     public void constructMod(FMLConstructionEvent event) {
         try {

--- a/src/main/java/org/spongepowered/mod/plugin/SpongePluginManager.java
+++ b/src/main/java/org/spongepowered/mod/plugin/SpongePluginManager.java
@@ -58,6 +58,10 @@ public class SpongePluginManager implements PluginManager {
         return ImmutableSet.copyOf((List) Loader.instance().getActiveModList());
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Optional<PluginContainer> fromInstance(Object instance) {
         if (instance instanceof PluginContainer) {

--- a/src/main/java/org/spongepowered/mod/plugin/WrappedModContainer.java
+++ b/src/main/java/org/spongepowered/mod/plugin/WrappedModContainer.java
@@ -44,6 +44,10 @@ public class WrappedModContainer implements PluginContainer {
         return this.container.getName();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public String getVersion() {
         return this.container.getVersion();

--- a/src/main/java/org/spongepowered/mod/potion/SpongePotionBuilder.java
+++ b/src/main/java/org/spongepowered/mod/potion/SpongePotionBuilder.java
@@ -44,6 +44,10 @@ public class SpongePotionBuilder implements PotionEffectBuilder {
         reset();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public PotionEffectBuilder potionType(PotionEffectType potionEffectType) {
         checkNotNull(potionEffectType, "Potion effect type cannot be null");

--- a/src/main/java/org/spongepowered/mod/registry/RegistryHelper.java
+++ b/src/main/java/org/spongepowered/mod/registry/RegistryHelper.java
@@ -53,6 +53,10 @@ class RegistryHelper {
         return mappingSuccess;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public static boolean mapFields(Class<?> apiClass, Function<String, ?> mapFunction) {
         boolean mappingSuccess = true;
         for (Field f : apiClass.getDeclaredFields()) {

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameDictionary.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameDictionary.java
@@ -58,6 +58,10 @@ public class SpongeGameDictionary implements GameDictionary {
         return items;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Map<String, Set<ItemType>> getAllItems() {
         HashMap<String, Set<ItemType>> allItems = Maps.newHashMap();

--- a/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/mod/registry/SpongeGameRegistry.java
@@ -260,6 +260,10 @@ import java.util.UUID;
 @NonnullByDefault
 public class SpongeGameRegistry implements GameRegistry {
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private final Map<String, BiomeType> biomeTypeMappings = Maps.newHashMap();
 
     public static final Map<Class<? extends WorldProvider>, SpongeConfig<SpongeConfig.DimensionConfig>> dimensionConfigs = Maps.newHashMap();

--- a/src/main/java/org/spongepowered/mod/rotation/SpongeRotation.java
+++ b/src/main/java/org/spongepowered/mod/rotation/SpongeRotation.java
@@ -38,4 +38,8 @@ public class SpongeRotation implements Rotation {
     public int getAngle() {
         return this.angle;
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/permission/DataFactoryCollection.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/DataFactoryCollection.java
@@ -67,6 +67,10 @@ public class DataFactoryCollection extends SpongeSubjectCollection {
         return ret;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean hasRegistered(String identifier) {
         return this.subjects.containsKey(identifier);

--- a/src/main/java/org/spongepowered/mod/service/permission/OpLevelCollection.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/OpLevelCollection.java
@@ -64,6 +64,10 @@ public class OpLevelCollection extends SpongeSubjectCollection {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean hasRegistered(String identifier) {
         return this.levels.containsKey(identifier);

--- a/src/main/java/org/spongepowered/mod/service/permission/SpongeContextCalculator.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/SpongeContextCalculator.java
@@ -51,6 +51,10 @@ public class SpongeContextCalculator implements ContextCalculator {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean matches(Context context, Subject subject) {
         Optional<CommandSource> subjSource = subject.getCommandSource();

--- a/src/main/java/org/spongepowered/mod/service/permission/SpongePermissionService.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/SpongePermissionService.java
@@ -57,6 +57,10 @@ public class SpongePermissionService implements PermissionService {
         }
     };
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private final ConcurrentMap<String, SubjectCollection> subjects = new ConcurrentHashMap<String, SubjectCollection>();
     private final MemorySubjectData defaultData;
 

--- a/src/main/java/org/spongepowered/mod/service/permission/UserCollection.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/UserCollection.java
@@ -49,6 +49,10 @@ public class UserCollection extends SpongeSubjectCollection {
         this.service = service;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Subject get(String identifier) {
         UUID uid = identToUuid(identifier);

--- a/src/main/java/org/spongepowered/mod/service/permission/UserSubject.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/UserSubject.java
@@ -47,6 +47,10 @@ public class UserSubject extends SpongeSubject {
     private final MemorySubjectData data;
     private final UserCollection collection;
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public UserSubject(final GameProfile player, final UserCollection users) {
         super(users.getService());
         this.player = player;

--- a/src/main/java/org/spongepowered/mod/service/permission/base/FixedParentMemorySubjectData.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/base/FixedParentMemorySubjectData.java
@@ -54,6 +54,10 @@ public class FixedParentMemorySubjectData extends GlobalMemorySubjectData {
         return ImmutableList.<Subject>builder().add(this.forcedParent).addAll(super.getParents(contexts)).build();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean addParent(Set<Context> contexts, Subject parent) {
         if (Objects.equal(this.forcedParent, parent) && GLOBAL_CONTEXT.equals(contexts)) {

--- a/src/main/java/org/spongepowered/mod/service/permission/base/GlobalMemorySubjectData.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/base/GlobalMemorySubjectData.java
@@ -52,6 +52,10 @@ public class GlobalMemorySubjectData extends MemorySubjectData {
         return ImmutableMap.of(GLOBAL_CONTEXT, getParents(GLOBAL_CONTEXT));
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean setPermission(Set<Context> contexts, String permission, Tristate value) {
         if (!GLOBAL_CONTEXT.equals(contexts)) {

--- a/src/main/java/org/spongepowered/mod/service/permission/base/SingleParentMemorySubjectData.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/base/SingleParentMemorySubjectData.java
@@ -52,6 +52,10 @@ public class SingleParentMemorySubjectData extends GlobalMemorySubjectData {
         return GLOBAL_CONTEXT.equals(contexts) && parent != null ? Collections.singletonList(parent) : Collections.<Subject>emptyList();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean addParent(Set<Context> contexts, Subject parent) {
         if (!(parent instanceof OpLevelCollection.OpLevelSubject)) {

--- a/src/main/java/org/spongepowered/mod/service/permission/base/SpongeSubject.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/base/SpongeSubject.java
@@ -57,6 +57,10 @@ public abstract class SpongeSubject implements Subject {
         return getPermissionValue(contexts, permission) == Tristate.TRUE;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public boolean hasPermission(String permission) {
         return hasPermission(getActiveContexts(), permission);

--- a/src/main/java/org/spongepowered/mod/service/permission/base/SpongeSubjectCollection.java
+++ b/src/main/java/org/spongepowered/mod/service/permission/base/SpongeSubjectCollection.java
@@ -58,6 +58,10 @@ public abstract class SpongeSubjectCollection implements SubjectCollection {
         return Collections.unmodifiableMap(ret);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Map<Subject, Boolean> getAllWithPermission(Set<Context> contexts, String permission) {
         final Map<Subject, Boolean> ret = new HashMap<Subject, Boolean>();

--- a/src/main/java/org/spongepowered/mod/service/persistence/NbtTranslator.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/NbtTranslator.java
@@ -67,6 +67,10 @@ public final class NbtTranslator implements DataTranslator<NBTTagCompound> {
         return compound;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private static void containerToCompound(final DataView container, final NBTTagCompound compound) {
         // We don't need to get deep values since all nested DataViews will be found
         // from the instance of checks.

--- a/src/main/java/org/spongepowered/mod/service/persistence/SpongeSerializationService.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/SpongeSerializationService.java
@@ -56,6 +56,10 @@ public class SpongeSerializationService implements SerializationService {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public <T extends DataSerializable> Optional<DataSerializableBuilder<T>> getBuilder(Class<T> clazz) {

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/data/SpongePatternLayerBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/data/SpongePatternLayerBuilder.java
@@ -68,4 +68,8 @@ public class SpongePatternLayerBuilder implements DataSerializableBuilder<Patter
         }
         return Optional.<PatternLayer>of(new SpongePatternLayer(shapeOptional.get(), colorOptional.get()));
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/AbstractTileBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/AbstractTileBuilder.java
@@ -80,6 +80,10 @@ public abstract class AbstractTileBuilder<T extends org.spongepowered.api.block.
         this.game = game;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     static {
         // These are our known block types. We need to find a way to support the mod ones
         addBlockMapping(TileEntityDropper.class, BlockTypes.DROPPER);

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBannerBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBannerBuilder.java
@@ -50,6 +50,10 @@ public class SpongeBannerBuilder extends AbstractTileBuilder<Banner> {
         super(game);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public Optional<Banner> build(DataView container) throws InvalidDataException {

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBeaconBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBeaconBuilder.java
@@ -48,6 +48,10 @@ public class SpongeBeaconBuilder extends SpongeLockableBuilder<Beacon> {
         super(game);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public Optional<Beacon> build(DataView container) throws InvalidDataException {

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBrewingStandBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeBrewingStandBuilder.java
@@ -40,6 +40,10 @@ public class SpongeBrewingStandBuilder extends SpongeLockableBuilder<BrewingStan
         super(game);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public Optional<BrewingStand> build(DataView container) throws InvalidDataException {

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeChestBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeChestBuilder.java
@@ -39,6 +39,10 @@ public class SpongeChestBuilder extends SpongeLockableBuilder<Chest> {
         super(game);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public Optional<Chest> build(DataView container) throws InvalidDataException {

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeCommandBlockBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeCommandBlockBuilder.java
@@ -63,4 +63,8 @@ public class SpongeCommandBlockBuilder extends AbstractTileBuilder<CommandBlock>
         ((TileEntityCommandBlock) commandblock).validate();
         return Optional.of(commandblock);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeComparatorBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeComparatorBuilder.java
@@ -48,4 +48,8 @@ public class SpongeComparatorBuilder extends AbstractTileBuilder<Comparator> {
         ((TileEntityComparator) comparatorOptional.get()).validate();
         return Optional.of(comparatorOptional.get());
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDaylightBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDaylightBuilder.java
@@ -48,4 +48,8 @@ public class SpongeDaylightBuilder extends AbstractTileBuilder<DaylightDetector>
         ((TileEntityDaylightDetector) daylightdetectorOptional.get()).validate();
         return Optional.of(daylightdetectorOptional.get());
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDispenserBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDispenserBuilder.java
@@ -53,4 +53,8 @@ public class SpongeDispenserBuilder extends SpongeLockableBuilder<Dispenser> {
         ((TileEntityDispenser) dispenser).validate();
         return Optional.of(dispenser);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDropperBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeDropperBuilder.java
@@ -53,4 +53,8 @@ public class SpongeDropperBuilder extends SpongeLockableBuilder<Dropper> {
         ((TileEntityDropper) dropper).validate();
         return Optional.of(dropper);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEnchantmentTableBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEnchantmentTableBuilder.java
@@ -53,4 +53,8 @@ public class SpongeEnchantmentTableBuilder extends AbstractTileBuilder<Enchantme
         ((TileEntityEnchantmentTable) enchantmenttable).validate();
         return Optional.of(enchantmenttable);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEndPortalBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEndPortalBuilder.java
@@ -48,4 +48,8 @@ public class SpongeEndPortalBuilder extends AbstractTileBuilder<EndPortal> {
         ((TileEntityEndPortal) endportalOptional.get()).validate();
         return Optional.of(endportalOptional.get());
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEnderChestBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeEnderChestBuilder.java
@@ -48,4 +48,8 @@ public class SpongeEnderChestBuilder extends AbstractTileBuilder<EnderChest> {
         ((TileEntityEnderChest) enderchestOptional.get()).validate();
         return Optional.of(enderchestOptional.get());
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeFurnaceBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeFurnaceBuilder.java
@@ -62,4 +62,8 @@ public class SpongeFurnaceBuilder extends SpongeLockableBuilder<Furnace> {
         ((TileEntityFurnace) furnace).validate();
         return Optional.of(furnace);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeHopperBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeHopperBuilder.java
@@ -58,4 +58,8 @@ public class SpongeHopperBuilder extends SpongeLockableBuilder<Hopper> {
         ((TileEntityHopper) hopper).validate();
         return Optional.of(hopper);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeLockableBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeLockableBuilder.java
@@ -69,4 +69,8 @@ public class SpongeLockableBuilder<T extends TileEntityCarrier> extends Abstract
 //        }
         return Optional.of((T) lockable);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeMobSpawnerBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeMobSpawnerBuilder.java
@@ -50,4 +50,8 @@ public class SpongeMobSpawnerBuilder extends AbstractTileBuilder<MobSpawner> {
         ((TileEntityMobSpawner) mobspawnerOptional.get()).validate();
         return Optional.of(mobspawnerOptional.get());
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeNoteBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeNoteBuilder.java
@@ -59,4 +59,8 @@ public class SpongeNoteBuilder extends AbstractTileBuilder<Note> {
         ((TileEntityNote) note).validate();
         return Optional.of(note);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeSignBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeSignBuilder.java
@@ -59,4 +59,8 @@ public class SpongeSignBuilder extends AbstractTileBuilder<Sign> {
         ((TileEntitySign) sign).validate();
         return Optional.of(sign);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeSkullBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/block/tile/SpongeSkullBuilder.java
@@ -54,4 +54,8 @@ public class SpongeSkullBuilder extends AbstractTileBuilder<Skull> {
         ((TileEntitySkull) skull).validate();
         return Optional.of(skull);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeDyeBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeDyeBuilder.java
@@ -46,4 +46,8 @@ public class SpongeDyeBuilder implements DataSerializableBuilder<DyeColor> {
         int id = container.getInt(new DataQuery("id")).get();
         return Optional.of((DyeColor) (Object) EnumDyeColor.byDyeDamage(id));
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeFireworkDataBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeFireworkDataBuilder.java
@@ -81,4 +81,8 @@ public class SpongeFireworkDataBuilder implements DataSerializableBuilder<Firewo
                                    .trail(trails)
                                    .build());
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseColorBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseColorBuilder.java
@@ -50,4 +50,8 @@ public class SpongeHorseColorBuilder implements DataSerializableBuilder<HorseCol
         }
         return Optional.of(color);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseStyleBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseStyleBuilder.java
@@ -50,4 +50,8 @@ public class SpongeHorseStyleBuilder implements DataSerializableBuilder<HorseSty
         }
         return Optional.of(color);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseVariantBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeHorseVariantBuilder.java
@@ -50,4 +50,8 @@ public class SpongeHorseVariantBuilder implements DataSerializableBuilder<HorseV
         }
         return Optional.of(color);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeOcelotTypeBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/data/SpongeOcelotTypeBuilder.java
@@ -50,4 +50,8 @@ public class SpongeOcelotTypeBuilder implements DataSerializableBuilder<OcelotTy
         }
         return Optional.of(ocelotType);
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/persistence/builders/potion/SpongePotionEffectBuilder.java
+++ b/src/main/java/org/spongepowered/mod/service/persistence/builders/potion/SpongePotionEffectBuilder.java
@@ -71,4 +71,8 @@ public class SpongePotionEffectBuilder implements DataSerializableBuilder<Potion
                                   .ambience(ambience)
                                   .build());
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/scheduler/AsyncScheduler.java
+++ b/src/main/java/org/spongepowered/mod/service/scheduler/AsyncScheduler.java
@@ -121,6 +121,10 @@ public class AsyncScheduler implements AsynchronousScheduler {
         }).start();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private void stateMachineBody() {
         this.executor = Executors.newCachedThreadPool();
         this.lastProcessingTimestamp = System.currentTimeMillis();

--- a/src/main/java/org/spongepowered/mod/service/scheduler/ScheduledTask.java
+++ b/src/main/java/org/spongepowered/mod/service/scheduler/ScheduledTask.java
@@ -62,6 +62,10 @@ public class ScheduledTask implements Task {
     private ScheduledTask() {
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     // This c'tor is OK for internal Sponge use. APIs do not expose the c'tor.
     protected ScheduledTask(long x, long t, TaskSynchroncity syncType) {
         // All tasks begin waiting.

--- a/src/main/java/org/spongepowered/mod/service/scheduler/SchedulerHelper.java
+++ b/src/main/java/org/spongepowered/mod/service/scheduler/SchedulerHelper.java
@@ -57,6 +57,10 @@ public class SchedulerHelper {
         return resultTask;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     /**
      * <p>
      * Start a repeating Task with a period (interval) of Ticks. The first

--- a/src/main/java/org/spongepowered/mod/service/scheduler/SchedulerLogMessages.java
+++ b/src/main/java/org/spongepowered/mod/service/scheduler/SchedulerLogMessages.java
@@ -46,4 +46,8 @@ public final class SchedulerLogMessages {
 
         return "SchedulerLogMessage";
     }
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/service/scheduler/SyncScheduler.java
+++ b/src/main/java/org/spongepowered/mod/service/scheduler/SyncScheduler.java
@@ -81,6 +81,10 @@ public class SyncScheduler implements SynchronousScheduler {
         return this.schedulerHelper.getTaskById(this.taskMap, id);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Optional<UUID> getUuidOfTaskByName(String name) {
 

--- a/src/main/java/org/spongepowered/mod/service/sql/SqlServiceImpl.java
+++ b/src/main/java/org/spongepowered/mod/service/sql/SqlServiceImpl.java
@@ -81,6 +81,10 @@ public class SqlServiceImpl implements SqlService, Closeable {
         PROTOCOL_SPECIFIC_PROPS = build.build();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private final LoadingCache<ConnectionInfo, HikariDataSource> connectionCache =
             CacheBuilder.newBuilder().removalListener(new RemovalListener<ConnectionInfo, HikariDataSource>() {
                 @Override

--- a/src/main/java/org/spongepowered/mod/status/SpongeFavicon.java
+++ b/src/main/java/org/spongepowered/mod/status/SpongeFavicon.java
@@ -56,6 +56,10 @@ public class SpongeFavicon implements Favicon {
         this.encoded = encode(decoded);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public SpongeFavicon(String encoded) throws IOException {
         this.encoded = checkNotNull(encoded, "encoded");
         this.decoded = decode(encoded);

--- a/src/main/java/org/spongepowered/mod/status/SpongeLegacyMinecraftVersion.java
+++ b/src/main/java/org/spongepowered/mod/status/SpongeLegacyMinecraftVersion.java
@@ -40,6 +40,10 @@ public class SpongeLegacyMinecraftVersion implements MinecraftVersion {
         this.latestVersion = latestVersion;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public SpongeLegacyMinecraftVersion(SpongeLegacyMinecraftVersion base, int version) {
         this.name = base.name;
         this.latestVersion = version;

--- a/src/main/java/org/spongepowered/mod/status/SpongeLegacyStatusClient.java
+++ b/src/main/java/org/spongepowered/mod/status/SpongeLegacyStatusClient.java
@@ -46,6 +46,10 @@ public class SpongeLegacyStatusClient implements StatusClient {
         this.virtualHost = Optional.fromNullable(virtualHost);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public InetSocketAddress getAddress() {
         return this.address;

--- a/src/main/java/org/spongepowered/mod/status/SpongeStatusClient.java
+++ b/src/main/java/org/spongepowered/mod/status/SpongeStatusClient.java
@@ -52,6 +52,10 @@ public class SpongeStatusClient implements StatusClient {
         return this.connection.getVersion();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Optional<InetSocketAddress> getVirtualHost() {
         return Optional.fromNullable(this.connection.getVirtualHost());

--- a/src/main/java/org/spongepowered/mod/status/SpongeStatusResponse.java
+++ b/src/main/java/org/spongepowered/mod/status/SpongeStatusResponse.java
@@ -60,6 +60,10 @@ public final class SpongeStatusResponse {
         return response;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     private static ServerStatusResponse call(ServerStatusResponse response, StatusClient client) {
         if (!SpongeMod.instance.getGame().getEventManager().post(SpongeEventFactory.createStatusPing(SpongeMod.instance.getGame(), client,
                 (StatusPingEvent.Response) response))) {

--- a/src/main/java/org/spongepowered/mod/text/ChatComponentIterable.java
+++ b/src/main/java/org/spongepowered/mod/text/ChatComponentIterable.java
@@ -41,4 +41,8 @@ public class ChatComponentIterable implements Iterable<IChatComponent> {
         return new ChatComponentIterator(this.component);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/text/ChatComponentIterator.java
+++ b/src/main/java/org/spongepowered/mod/text/ChatComponentIterator.java
@@ -48,6 +48,10 @@ public class ChatComponentIterator extends UnmodifiableIterator<IChatComponent> 
         return this.children == null || (this.currentChildIterator != null && this.currentChildIterator.hasNext()) || this.children.hasNext();
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public IChatComponent next() {

--- a/src/main/java/org/spongepowered/mod/text/SpongeTextFactory.java
+++ b/src/main/java/org/spongepowered/mod/text/SpongeTextFactory.java
@@ -54,6 +54,10 @@ public class SpongeTextFactory implements TextFactory {
         }
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public Text parseJsonLenient(String json) throws IllegalArgumentException {
         return parseJson(json); // TODO

--- a/src/main/java/org/spongepowered/mod/text/action/SpongeClickAction.java
+++ b/src/main/java/org/spongepowered/mod/text/action/SpongeClickAction.java
@@ -49,4 +49,8 @@ public final class SpongeClickAction {
         return new ClickEvent(getType(action), action.getResult().toString());
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/text/action/SpongeHoverAction.java
+++ b/src/main/java/org/spongepowered/mod/text/action/SpongeHoverAction.java
@@ -53,6 +53,10 @@ public class SpongeHoverAction {
         throw new UnsupportedOperationException(action.getClass().toString());
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public static HoverEvent getHandle(HoverAction<?> action) {
         HoverEvent.Action type = getType(action);
         IChatComponent component;

--- a/src/main/java/org/spongepowered/mod/text/chat/SpongeChatType.java
+++ b/src/main/java/org/spongepowered/mod/text/chat/SpongeChatType.java
@@ -38,4 +38,8 @@ public class SpongeChatType implements ChatType {
         return this.id;
     }
 
+
+    public boolean isFlowerPot() {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/mod/text/format/SpongeTextColor.java
+++ b/src/main/java/org/spongepowered/mod/text/format/SpongeTextColor.java
@@ -64,6 +64,10 @@ public class SpongeTextColor implements TextColor.Base {
         return this.handle.formattingCode;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public String toString() {
         return getName();

--- a/src/main/java/org/spongepowered/mod/text/format/SpongeTextStyle.java
+++ b/src/main/java/org/spongepowered/mod/text/format/SpongeTextStyle.java
@@ -54,6 +54,10 @@ public class SpongeTextStyle extends TextStyle.Base {
         return this.handle.formattingCode;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public static SpongeTextStyle of(EnumChatFormatting handle) {
         if (handle == EnumChatFormatting.RESET) {
             return new SpongeTextStyle(handle, false, false, false, false, false);

--- a/src/main/java/org/spongepowered/mod/text/translation/SpongeTranslation.java
+++ b/src/main/java/org/spongepowered/mod/text/translation/SpongeTranslation.java
@@ -47,6 +47,10 @@ public class SpongeTranslation implements Translation {
         return StatCollector.translateToLocal(this.id);
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @Override
     public String get(Object... args) {
         return StatCollector.translateToLocalFormatted(this.id, args);

--- a/src/main/java/org/spongepowered/mod/util/SpongeHooks.java
+++ b/src/main/java/org/spongepowered/mod/util/SpongeHooks.java
@@ -82,6 +82,10 @@ public class SpongeHooks {
         MinecraftServer.getServer().logSevere(MessageFormat.format(msg, args));
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     public static void logStack(SpongeConfig<?> config) {
         if (config.getConfig().getLogging().logWithStackTraces()) {
             Throwable ex = new Throwable();

--- a/src/main/java/org/spongepowered/mod/util/VecHelper.java
+++ b/src/main/java/org/spongepowered/mod/util/VecHelper.java
@@ -51,6 +51,10 @@ public final class VecHelper {
         return new Vector3i(pos.getX(), pos.getY(), pos.getZ());
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 
     // === Rotations --> Flow Vector ===
 

--- a/src/main/java/org/spongepowered/mod/util/VectorSerializer.java
+++ b/src/main/java/org/spongepowered/mod/util/VectorSerializer.java
@@ -43,4 +43,8 @@ public class VectorSerializer {
         return new Vector3d(compound.getDouble("x"), compound.getDouble("y"), compound.getDouble("z"));
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/weather/SpongeWeather.java
+++ b/src/main/java/org/spongepowered/mod/weather/SpongeWeather.java
@@ -30,4 +30,8 @@ import org.spongepowered.api.world.weather.Weather;
 @NonnullByDefault
 public class SpongeWeather implements Weather {
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
 }

--- a/src/main/java/org/spongepowered/mod/world/SpongeDimensionType.java
+++ b/src/main/java/org/spongepowered/mod/world/SpongeDimensionType.java
@@ -51,6 +51,10 @@ public class SpongeDimensionType implements DimensionType {
         return this.name;
     }
 
+    public boolean isFlowerPot() {
+        return false;
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public Class<? extends Dimension> getDimensionClass() {


### PR DESCRIPTION
Implements https://github.com/kenzierocks/SpongeAPI/pull/1
# Proposal for unified isFlowerPot detection

Whilst it is well understood at this point that a well-specified and suitably future-proof API for Minecraft will need to be appropriately decoupled from Minecraft internals to withstand future changes to the underlying platform as effectively as possible, there are some aspects of the underlying platform which are intrinsically immutable and thus safe to propagate up to the API layer.

In many cases it is fully possible to achieve high levels of abstraction within the API, as demonstrated by the recent additions of the Inventory API and Item Data API. However there are still places where abstraction simply does not provide any measurable benefit to the end user, and adhering more faithfully to the internal architecture of the underlying Minecraft platform has no immediate or developer-facing drawbacks.

Where we can achieve some tangible improvement however is in homogenising developer-facing interfaces in order to provide a consistent and intuitive aspect-oriented development paradigm, reinforced by rigid adherance to integrated vertical software development disciplines.
### The Chaos at the Heart of Minecraft

With Minecraft, what you see is not always what you get. Crowd-sourced names for internal API structures can often fall somewhat short of making any sense whatsoever, but still provide valuable insight for newcomers into Minecraft internals, albeit tainted by occasionally apocryphal or sometimes downright nonsensical assignment of meaning to something that the assignor didn't understand or couldn't be bothered to decipher. Nevertheless, these little curios persist in the deobfuscated Minecraft codebase, and their legacy is one of some entertainment and wry humor when the truth of a particular field or method's origins come to light.

The typical ways of dealing with these conflicts between the _status quo_ and common sense resolve into two camps:
- Argue about it pretty much forever
- Accept the nonsense and move on

An example of the former is the most hotly contested field of all time `World.isRemote`, sorry I meant `World.isClient` or is that `World.isR...` okay, okay I'll stop. However one of the most notable examples of the latter is the somewhat controversially named `isFlowerPot` method in Minecraft's `Block` class.

This method and its somewhat peculiar naming was the subject of some discussion until a Mojangsta was nailed down and forced to cough up the original name, which turned out to be something like `handlesOwnClone`, however the charm of the original (kind of quirky and entertaining) `isFlowerPot` was just too strong, and the method maintains its apocryphal nomenclature to this day.
### ClassLoading and You - a ~~song of ice and fire~~ soliloquy in five parts

Everyone is aware that Sponge is powered by ~~black magic~~ Mixins, however Class Loading in Java is a complex topic and Mixins are unable to adequately solve every problem we might throw at them. Fundamental to the successful application of Mixins is the core idea that a mixin is used to implement some aspect of the defined API.

`isFlowerPot` thus presents a problem. How can we adequately represent whether or not something is a flowerpot or not if we don't adequately encode this crucial information in the developer-facing portions of the API?

The answer is: define this information explicitly in each interface.

Taking a purely java-based approach to solving this problem alleviates several issues which would otherwise be caused. Whilst we could of course inject the required code at runtime, this rapidly becomes a very expensive operation when we factor in the sheer number of classes involved, and also the potential conflicts it creates with other non-flowerpot-aware code.

The beauty of this extremely [elegant](https://github.com/kenzierocks/SpongeAPI/commits/hotfix/instance-checks?page=16) and efficient implementation approach is that it provides a unified and 100 percent intuitive way of determining whether literally **any** object is or is not a flowerpot at runtime, without introducing complex transformer logic or polluting existing mixins with unrelated code. This allows mixins to focus on their task of implementing literally everything, whilst `isFlowerPot` logic can be handled in pure Java at a fundamental level within both the API and the Sponge implementation.
